### PR TITLE
Fix the docker build error for ubuntu 22.04

### DIFF
--- a/.devops/rocm.Dockerfile
+++ b/.devops/rocm.Dockerfile
@@ -80,6 +80,10 @@ RUN apt-get update \
     python3-pip \
     python3 \
     python3-wheel\
+    && (CURRENT_PIP_VERSION=$(pip --version | awk '{print $2}') \
+        && dpkg --compare-versions "$CURRENT_PIP_VERSION" lt "23.1" \
+        && python3 -m pip install --upgrade pip \
+        || echo "pip >= 23.1, no upgrade needed") \
     && pip install --break-system-packages --upgrade setuptools \
     && pip install --break-system-packages -r requirements.txt \
     && apt autoremove -y \


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

1. The error only happens in ubuntu 22.04 where pip version is 22.02
2. The --break-system-packages is introduced in 23.1
3. Removing --break-system-packages does not fix, because it will break the ubuntu 24.04, with an error that pip is externally-managed-environment
4. Adding python3 -m pip install --upgrade pip will only work for ubutun 22.04, but not 24.04 because the same error occur.