### PR TITLE
rm rocwmma before the clone to make sure docker builds

### DIFF
--- a/.devops/rocm.Dockerfile
+++ b/.devops/rocm.Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN git clone https://github.com/rocm/rocwmma --branch develop --depth 1
+RUN rm -rf rocwmma && git clone https://github.com/rocm/rocwmma --branch develop --depth 1
 
 RUN HIPCXX="$(hipconfig -l)/clang" HIP_PATH="$(hipconfig -R)" \
     cmake -S . -B build \


### PR DESCRIPTION
- git clone will fail for ci pipeline due to cache issues
- rm rocwmma before the clone to make sure docker builds in ci
