### PR TITLE
HRX CI: run on self-hosted ROCm GPU runners for gfx1151/gfx1201

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -16,7 +16,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-android.yml',

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -16,6 +16,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-android.yml',

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -19,6 +19,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-apple.yml',

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -19,7 +19,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-apple.yml',

--- a/.github/workflows/build-cann.yml
+++ b/.github/workflows/build-cann.yml
@@ -16,7 +16,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-cann.yml',

--- a/.github/workflows/build-cann.yml
+++ b/.github/workflows/build-cann.yml
@@ -16,6 +16,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-cann.yml',

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -34,26 +34,9 @@ jobs:
     timeout-minutes: 60
     defaults:
       run:
-        # The container default is sh; the bench scripts require bash.
         shell: bash
-    # The self-hosted ROCm runners require jobs to run in a container; plain
-    # run steps fail in the runner-controller's direct-execution hook.
-    # Image and options mirror TheRock CI
-    # (build_tools/github_actions/fetch_test_configurations.py).
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26
-      options: >-
-        --ipc host
-        --user 0:0
-        --ulimit memlock=-1:-1
-        --security-opt seccomp=unconfined
-        --group-add video
-        --device /dev/kfd
-        --device /dev/dri
-        --group-add 993
-        --group-add 992
-        --group-add 110
-        --env-file /etc/podinfo/gha-gpu-isolation-settings
     env:
       HRX_WORK_DIR: ${{ github.workspace }}
       # Public location for bench tooling (rsuderman/llamacpp_ci and fork

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -71,7 +71,7 @@ jobs:
       # AaronStGeorge/llamacpp_ci)
       #TODO: switch to ROCm/llamacpp-hrx-bench once it is open sourced.
       BENCH_REPOSITORY: AaronStGeorge/llamacpp_ci
-      BENCH_REF: 'main'
+      BENCH_REF: 'runner-health'
       # actions/checkout@v6 does auto-cleanup, an in-tree build would be
       # auto-cleaned as well.
       BENCH_DIR: ${{ github.workspace }}/bench
@@ -155,6 +155,37 @@ jobs:
 
       - name: Build llama.cpp with HRX
         run: "${BENCH_DIR}/scripts/hrx/build-llama-hrx.sh"
+
+      # Diagnostic: run the failing MUL_MAT config N times in THIS job to measure
+      # the per-RUNNER failure rate -- does a bad machine fail every iteration or
+      # only some? Advisory (continue-on-error, runs BEFORE the gating step so it
+      # still executes on a failing machine). Correlate the printed count with
+      # RUNNER_NAME (see the Debug step). Tune N via the MULMAT_LOOP_N var.
+      - name: MUL_MAT failure-rate loop (diagnostic)
+        continue-on-error: true
+        timeout-minutes: 20
+        run: |
+          . "${BENCH_DIR}/scripts/hrx/env.sh"
+          . "${BENCH_DIR}/scripts/hrx/runtime-env.sh"
+          set +e   # count pass/fail from the output, don't let a NaN exit abort
+          TB="${LLAMA_BUILD_DIR}/bin/test-backend-ops"
+          TF="${BENCH_DIR}/benchmark-configs/test/mul_mat_f16.txt"
+          N="${MULMAT_LOOP_N:-50}"
+          pass=0; fail=0; other=0
+          for i in $(seq 1 "$N"); do
+            out="$("$TB" test -o MUL_MAT -b HRX0 --test-file "$TF" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+            if echo "$out" | grep -q 'NaN at index'; then
+              fail=$((fail+1))
+              [ "$fail" -le 3 ] && echo "iter $i FAIL: $(echo "$out" | grep -m1 'NaN at index')"
+            elif echo "$out" | grep -q '1/1 tests passed'; then
+              pass=$((pass+1))
+            else
+              other=$((other+1))
+              [ "$other" -le 2 ] && echo "iter $i OTHER: $(echo "$out" | tail -2 | tr '\n' ' ')"
+            fi
+          done
+          echo "MULMAT_RATE runner=${RUNNER_NAME} fail=${fail} pass=${pass} other=${other} total=${N}"
+          echo "::notice::MUL_MAT rate on ${RUNNER_NAME}: ${fail}/${N} FAIL (pass=${pass}, other=${other})"
 
       - name: Run sample MUL_MAT correctness config on HRX
         timeout-minutes: 15

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -83,6 +83,31 @@ jobs:
       CCACHE_COMPILERCHECK: content
 
     steps:
+      # Logged first (if: always(), before any checkout) so the specific
+      # self-hosted runner behind a failure is greppable from the job log via
+      # RUNNER_NAME, without querying the GitHub API. NOTE: a gfx1201
+      # "Initialize containers" failure happens before any step runs, so this
+      # block cannot capture that mode -- only the API runner_name identifies it.
+      - name: Debug (runner identity)
+        if: always()
+        run: |
+          set +e
+          echo "===== RUNNER IDENTITY ====="
+          echo "RUNNER_NAME=${RUNNER_NAME}"
+          echo "RUNNER_OS=${RUNNER_OS}  RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT}"
+          echo "GITHUB_RUN_ID=${GITHUB_RUN_ID} attempt=${GITHUB_RUN_ATTEMPT} job=${GITHUB_JOB}"
+          echo "matrix.name=${{ matrix.name }} gpu_target=${{ matrix.gpu_target }} runs_on=${{ matrix.runs_on }}"
+          echo "hostname=$(hostname)"
+          uname -a || true
+          cat /etc/os-release || true
+          id || true
+          ls -l /dev/kfd || echo "MISSING /dev/kfd"
+          ls -l /dev/dri || echo "MISSING /dev/dri"
+          lspci | grep -iE 'vga|display|amd/ati' || echo "lspci unavailable / no GPU match"
+          env | grep -E '^(RUNNER_|GITHUB_)' | sort || true
+          echo "===== END RUNNER IDENTITY ====="
+          true
+
       - name: Checkout llama.cpp (under test)
         uses: actions/checkout@v6
         with:
@@ -110,6 +135,15 @@ jobs:
 
       - name: Fetch ROCm assets
         run: "${BENCH_DIR}/scripts/hrx/fetch-rocm-assets.sh"
+
+      # Dump GPU/board identity (serial/VBIOS/fw via rocminfo/amd-smi/rocm-smi)
+      # and fail fast on gross breakage (no /dev/kfd, dead rocminfo, expected
+      # gfx arch not enumerated) before the costly HRX/llama build. Runs here
+      # because the diag binaries only exist in the composed prefix after the
+      # fetch step. Does NOT detect the gfx1151 coherence NaN flake.
+      - name: GPU health check
+        timeout-minutes: 3
+        run: "${BENCH_DIR}/scripts/hrx/runner-health.sh"
 
       - name: Build HRX
         run: "${BENCH_DIR}/scripts/hrx/build-hrx.sh"

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -34,7 +34,7 @@ jobs:
             runs_on: linux-gfx120X-gpu-rocm
             extra_rocm_artifacts: rocwmma_dev_gfx120X-all
     runs-on: ${{ matrix.runs_on }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     defaults:
       run:
         # --noprofile skips loading ~/.bash_profile
@@ -71,23 +71,17 @@ jobs:
       # AaronStGeorge/llamacpp_ci)
       #TODO: switch to ROCm/llamacpp-hrx-bench once it is open sourced.
       BENCH_REPOSITORY: AaronStGeorge/llamacpp_ci
-      BENCH_REF: 'runner-health'
+      BENCH_REF: 'main'
       # actions/checkout@v6 does auto-cleanup, an in-tree build would be
       # auto-cleaned as well.
       BENCH_DIR: ${{ github.workspace }}/bench
       LLAMA_SRC_DIR: ${{ github.workspace }}/llama-src
-      # Build tree off the bind mount too (source stays under the workspace).
       LLAMA_BUILD_DIR: /work/llama-build
       HRX_EXTRA_ROCM_ARTIFACTS: ${{ matrix.extra_rocm_artifacts }}
       GGML_HRX_AMDGPU_TARGETS: ${{ matrix.gpu_target }}
       CCACHE_COMPILERCHECK: content
 
     steps:
-      - name: Checkout llama.cpp (under test)
-        uses: actions/checkout@v6
-        with:
-          path: llama-src
-
       - name: Checkout bench tooling
         uses: actions/checkout@v6
         with:
@@ -95,18 +89,17 @@ jobs:
           ref: ${{ env.BENCH_REF }}
           path: bench
 
-      # Runner identity dump -- logs RUNNER_NAME so the specific self-hosted
-      # runner behind a failure is greppable from the job log. Runs right after
-      # the bench checkout (earliest a bench script is available); if: always()
-      # so it still logs when a later step fails. NOTE: a gfx1201 "Initialize
-      # containers" failure happens before any step runs and isn't captured here.
-      - name: Debug (runner identity)
-        if: always()
+      - name: Runner info
         env:
           MATRIX_NAME: ${{ matrix.name }}
           MATRIX_GPU_TARGET: ${{ matrix.gpu_target }}
           MATRIX_RUNS_ON: ${{ matrix.runs_on }}
-        run: "${BENCH_DIR}/scripts/hrx/runner-identity.sh"
+        run: "${BENCH_DIR}/scripts/hrx/runner-info.sh"
+
+      - name: Checkout llama.cpp (under test)
+        uses: actions/checkout@v6
+        with:
+          path: llama-src
 
       - name: Install ROCm build dependencies
         run: "${BENCH_DIR}/scripts/hrx/install-rocm-deps.sh"
@@ -124,59 +117,16 @@ jobs:
       - name: Fetch ROCm assets
         run: "${BENCH_DIR}/scripts/hrx/fetch-rocm-assets.sh"
 
-      # Dump GPU/board identity (serial/VBIOS/fw via rocminfo/amd-smi/rocm-smi)
-      # and fail fast on gross breakage (no /dev/kfd, dead rocminfo, expected
-      # gfx arch not enumerated) before the costly HRX/llama build. Runs here
-      # because the diag binaries only exist in the composed prefix after the
-      # fetch step. Does NOT detect the gfx1151 coherence NaN flake.
-      - name: GPU health check
-        timeout-minutes: 3
-        run: "${BENCH_DIR}/scripts/hrx/runner-health.sh"
-
       - name: Build HRX
         run: "${BENCH_DIR}/scripts/hrx/build-hrx.sh"
 
       - name: Validate HRX
-        # hrx-info has been observed hanging on some runners; fail fast.
-        timeout-minutes: 5
         run: "${BENCH_DIR}/scripts/hrx/validate-hrx.sh"
 
       - name: Build llama.cpp with HRX
         run: "${BENCH_DIR}/scripts/hrx/build-llama-hrx.sh"
 
-      # Diagnostic: run the failing MUL_MAT config N times in THIS job to measure
-      # the per-RUNNER failure rate -- does a bad machine fail every iteration or
-      # only some? Advisory (continue-on-error, runs BEFORE the gating step so it
-      # still executes on a failing machine). Correlate the printed count with
-      # RUNNER_NAME (see the Debug step). Tune N via the MULMAT_LOOP_N var.
-      - name: MUL_MAT failure-rate loop (diagnostic)
-        continue-on-error: true
-        timeout-minutes: 20
-        run: |
-          . "${BENCH_DIR}/scripts/hrx/env.sh"
-          . "${BENCH_DIR}/scripts/hrx/runtime-env.sh"
-          set +e   # count pass/fail from the output, don't let a NaN exit abort
-          TB="${LLAMA_BUILD_DIR}/bin/test-backend-ops"
-          TF="${BENCH_DIR}/benchmark-configs/test/mul_mat_f16.txt"
-          N="${MULMAT_LOOP_N:-50}"
-          pass=0; fail=0; other=0
-          for i in $(seq 1 "$N"); do
-            out="$("$TB" test -o MUL_MAT -b HRX0 --test-file "$TF" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
-            if echo "$out" | grep -q 'NaN at index'; then
-              fail=$((fail+1))
-              [ "$fail" -le 3 ] && echo "iter $i FAIL: $(echo "$out" | grep -m1 'NaN at index')"
-            elif echo "$out" | grep -q '1/1 tests passed'; then
-              pass=$((pass+1))
-            else
-              other=$((other+1))
-              [ "$other" -le 2 ] && echo "iter $i OTHER: $(echo "$out" | tail -2 | tr '\n' ' ')"
-            fi
-          done
-          echo "MULMAT_RATE runner=${RUNNER_NAME} fail=${fail} pass=${pass} other=${other} total=${N}"
-          echo "::notice::MUL_MAT rate on ${RUNNER_NAME}: ${fail}/${N} FAIL (pass=${pass}, other=${other})"
-
       - name: Run sample MUL_MAT correctness config on HRX
-        timeout-minutes: 15
         run: |
           . "${BENCH_DIR}/scripts/hrx/env.sh"
           . "${BENCH_DIR}/scripts/hrx/runtime-env.sh"
@@ -188,7 +138,6 @@ jobs:
             --output benchmark-results/sample-mul-mat-f16-hrx-test.jsonl
 
       - name: Run sample MUL_MAT benchmark config on HRX
-        timeout-minutes: 15
         run: |
           . "${BENCH_DIR}/scripts/hrx/env.sh"
           . "${BENCH_DIR}/scripts/hrx/runtime-env.sh"

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -44,8 +44,24 @@ jobs:
         shell: bash --noprofile --norc -exo pipefail {0}
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:fba5f55a122dbb15925e98c51fe65bffe88c36e11ebb25b73daf2bea04202dc3
+      # --user 0:0: Actions needs to access some files set up as part of the
+      #             Actions runner. In June 2026 some runners are set up with a
+      #             "tester" user with UID/GID 1001 which matches the user in
+      #             the container, and some are set up as root. Running as root
+      #             is the common denominator, accessing a file owned by root
+      #             with user "tester" gives an EACCES.
+      # --device kfd/dri: GPU access; the plain runner adds no devices for us.
+      options: >-
+        --user 0:0
+        --device /dev/kfd
+        --device /dev/dri
     env:
-      HRX_WORK_DIR: ${{ github.workspace }}
+      # Write to a non bind-mounted directory. In June 2026 a debug tests showed
+      # some runners hat assets dated from 6 months ago in the bind-mounted
+      # github workspace, it seems like nothing cleans it up currently. Writing
+      # to an non-bind mounted directory ensures that rocm-artifacts/builds are
+      # cleaned up when docker conteriner is removed.
+      HRX_WORK_DIR: /work
       # Public location for bench tooling (rsuderman/llamacpp_ci and fork
       # AaronStGeorge/llamacpp_ci)
       #TODO: switch to ROCm/llamacpp-hrx-bench once it is open sourced.
@@ -54,6 +70,8 @@ jobs:
       BENCH_REF: 'p066-multi-arch-ci'
       BENCH_DIR: ${{ github.workspace }}/bench
       LLAMA_SRC_DIR: ${{ github.workspace }}/llama-src
+      # Build tree off the bind mount too (source stays under the workspace).
+      LLAMA_BUILD_DIR: /work/llama-build
       HRX_EXTRA_ROCM_ARTIFACTS: ${{ matrix.extra_rocm_artifacts }}
       GGML_HRX_AMDGPU_TARGETS: ${{ matrix.gpu_target }}
       CCACHE_COMPILERCHECK: content

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -83,31 +83,6 @@ jobs:
       CCACHE_COMPILERCHECK: content
 
     steps:
-      # Logged first (if: always(), before any checkout) so the specific
-      # self-hosted runner behind a failure is greppable from the job log via
-      # RUNNER_NAME, without querying the GitHub API. NOTE: a gfx1201
-      # "Initialize containers" failure happens before any step runs, so this
-      # block cannot capture that mode -- only the API runner_name identifies it.
-      - name: Debug (runner identity)
-        if: always()
-        run: |
-          set +e
-          echo "===== RUNNER IDENTITY ====="
-          echo "RUNNER_NAME=${RUNNER_NAME}"
-          echo "RUNNER_OS=${RUNNER_OS}  RUNNER_ENVIRONMENT=${RUNNER_ENVIRONMENT}"
-          echo "GITHUB_RUN_ID=${GITHUB_RUN_ID} attempt=${GITHUB_RUN_ATTEMPT} job=${GITHUB_JOB}"
-          echo "matrix.name=${{ matrix.name }} gpu_target=${{ matrix.gpu_target }} runs_on=${{ matrix.runs_on }}"
-          echo "hostname=$(hostname)"
-          uname -a || true
-          cat /etc/os-release || true
-          id || true
-          ls -l /dev/kfd || echo "MISSING /dev/kfd"
-          ls -l /dev/dri || echo "MISSING /dev/dri"
-          lspci | grep -iE 'vga|display|amd/ati' || echo "lspci unavailable / no GPU match"
-          env | grep -E '^(RUNNER_|GITHUB_)' | sort || true
-          echo "===== END RUNNER IDENTITY ====="
-          true
-
       - name: Checkout llama.cpp (under test)
         uses: actions/checkout@v6
         with:
@@ -119,6 +94,19 @@ jobs:
           repository: ${{ env.BENCH_REPOSITORY }}
           ref: ${{ env.BENCH_REF }}
           path: bench
+
+      # Runner identity dump -- logs RUNNER_NAME so the specific self-hosted
+      # runner behind a failure is greppable from the job log. Runs right after
+      # the bench checkout (earliest a bench script is available); if: always()
+      # so it still logs when a later step fails. NOTE: a gfx1201 "Initialize
+      # containers" failure happens before any step runs and isn't captured here.
+      - name: Debug (runner identity)
+        if: always()
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_GPU_TARGET: ${{ matrix.gpu_target }}
+          MATRIX_RUNS_ON: ${{ matrix.runs_on }}
+        run: "${BENCH_DIR}/scripts/hrx/runner-identity.sh"
 
       - name: Install ROCm build dependencies
         run: "${BENCH_DIR}/scripts/hrx/install-rocm-deps.sh"

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -68,8 +68,7 @@ jobs:
       # AaronStGeorge/llamacpp_ci)
       #TODO: switch to ROCm/llamacpp-hrx-bench once it is open sourced.
       BENCH_REPOSITORY: AaronStGeorge/llamacpp_ci
-      #TODO: restore to main once p066-multi-arch-ci merges in the bench repo.
-      BENCH_REF: 'p066-multi-arch-ci'
+      BENCH_REF: 'main'
       # actions/checkout@v6 does auto-cleanup, an in-tree build would be
       # auto-cleaned as well.
       BENCH_DIR: ${{ github.workspace }}/bench
@@ -130,6 +129,7 @@ jobs:
         timeout-minutes: 15
         run: |
           . "${BENCH_DIR}/scripts/hrx/env.sh"
+          . "${BENCH_DIR}/scripts/hrx/runtime-env.sh"
           "${BENCH_DIR}/tools/run-op-test.py" \
             --test-backend-ops "${LLAMA_BUILD_DIR}/bin/test-backend-ops" \
             --test-file "${BENCH_DIR}/benchmark-configs/test/mul_mat_f16.txt" \
@@ -141,6 +141,7 @@ jobs:
         timeout-minutes: 15
         run: |
           . "${BENCH_DIR}/scripts/hrx/env.sh"
+          . "${BENCH_DIR}/scripts/hrx/runtime-env.sh"
           "${BENCH_DIR}/tools/run-op-perf.py" \
             --test-backend-ops "${LLAMA_BUILD_DIR}/bin/test-backend-ops" \
             --test-file "${BENCH_DIR}/benchmark-configs/test/mul_mat_f16.txt" \

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -44,23 +44,25 @@ jobs:
         shell: bash --noprofile --norc -exo pipefail {0}
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:fba5f55a122dbb15925e98c51fe65bffe88c36e11ebb25b73daf2bea04202dc3
-      # --user 0:0: Actions needs to access some files set up as part of the
-      #             Actions runner. In June 2026 some runners are set up with a
-      #             "tester" user with UID/GID 1001 which matches the user in
-      #             the container, and some are set up as root. Running as root
-      #             is the common denominator, accessing a file owned by root
-      #             with user "tester" gives an EACCES.
+      # --user 0:0: actions running inside the container need to write to some
+      #             files set up by the runner agent before the container runs.
+      #             In June 2026 some runner agents set those files up with
+      #             permissions for a "tester" user with UID/GID 1001 which
+      #             matches the user in no_rocm_image_ubuntu24_04, and some are
+      #             set up as root; accessing a file owned by root with user
+      #             "tester" gives an EACCES. Running as root is the common
+      #             denominator.
       # --device kfd/dri: GPU access; the plain runner adds no devices for us.
       options: >-
         --user 0:0
         --device /dev/kfd
         --device /dev/dri
     env:
-      # Write to a non bind-mounted directory. In June 2026 a debug tests showed
-      # some runners hat assets dated from 6 months ago in the bind-mounted
-      # github workspace, it seems like nothing cleans it up currently. Writing
-      # to an non-bind mounted directory ensures that rocm-artifacts/builds are
-      # cleaned up when docker conteriner is removed.
+      # Write out of tree build/install to a non-bind-mounted directory. In June
+      # 2026 a debug test showed some runners had assets dated from 6 months ago
+      # in the bind-mounted github workspace, it seems like nothing cleans it up
+      # currently. Writing to an non-bind-mounted directory ensures that
+      # rocm-artifacts/builds are cleaned up when docker container is removed.
       HRX_WORK_DIR: /work
       # Public location for bench tooling (rsuderman/llamacpp_ci and fork
       # AaronStGeorge/llamacpp_ci)
@@ -68,6 +70,8 @@ jobs:
       BENCH_REPOSITORY: AaronStGeorge/llamacpp_ci
       #TODO: restore to main once p066-multi-arch-ci merges in the bench repo.
       BENCH_REF: 'p066-multi-arch-ci'
+      # actions/checkout@v6 does auto-cleanup, an in-tree build would be
+      # auto-cleaned as well.
       BENCH_DIR: ${{ github.workspace }}/bench
       LLAMA_SRC_DIR: ${{ github.workspace }}/llama-src
       # Build tree off the bind mount too (source stays under the workspace).

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -34,9 +34,16 @@ jobs:
     timeout-minutes: 60
     defaults:
       run:
-        shell: bash
+        # --noprofile skips loading ~/.bash_profile
+        # --norc      skips loading ~/.bashrc
+        # -exo pipefail:
+        #   -e exit immediately if any command fails
+        #   -x print each command before executing
+        #   -o pipefail ensure pipeline fails if any command in it fails
+        # {0} github actions placeholder for the command to run
+        shell: bash --noprofile --norc -exo pipefail {0}
     container:
-      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:fba5f55a122dbb15925e98c51fe65bffe88c36e11ebb25b73daf2bea04202dc3
     env:
       HRX_WORK_DIR: ${{ github.workspace }}
       # Public location for bench tooling (rsuderman/llamacpp_ci and fork
@@ -52,6 +59,12 @@ jobs:
       CCACHE_COMPILERCHECK: content
 
     steps:
+      - name: Debug
+        run: |
+          id
+          ls -ln /__w/_temp | head
+          ls -ln /__w | head
+
       - name: Checkout llama.cpp (under test)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -1,6 +1,9 @@
 name: HRX CI
 
 on:
+  push:
+    branches:
+      - hrx-integration
   pull_request:
     types: [opened, synchronize, reopened]
     branches:

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -31,7 +31,7 @@ jobs:
             runs_on: linux-gfx120X-gpu-rocm
             extra_rocm_artifacts: rocwmma_dev_gfx120X-all
     runs-on: ${{ matrix.runs_on }}
-    timeout-minutes: 60
+    timeout-minutes: 15
     defaults:
       run:
         # --noprofile skips loading ~/.bash_profile
@@ -45,14 +45,14 @@ jobs:
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:fba5f55a122dbb15925e98c51fe65bffe88c36e11ebb25b73daf2bea04202dc3
       # --user 0:0: actions running inside the container need to write to some
-      #             files set up by the runner agent before the container runs.
-      #             In June 2026 some runner agents set those files up with
-      #             permissions for a "tester" user with UID/GID 1001 which
+      #             files set up outside the container by the runner agent.  In
+      #             June 2026 some runner agents set those files up with
+      #             permissions for a "tester" user with UID/GID 1001, which
       #             matches the user in no_rocm_image_ubuntu24_04, and some are
       #             set up as root; accessing a file owned by root with user
       #             "tester" gives an EACCES. Running as root is the common
       #             denominator.
-      # --device kfd/dri: GPU access; the plain runner adds no devices for us.
+      # --device kfd/dri: GPU access.
       options: >-
         --user 0:0
         --device /dev/kfd
@@ -80,12 +80,6 @@ jobs:
       CCACHE_COMPILERCHECK: content
 
     steps:
-      - name: Debug
-        run: |
-          id
-          ls -ln /__w/_temp | head
-          ls -ln /__w | head
-
       - name: Checkout llama.cpp (under test)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-hrx.yml
+++ b/.github/workflows/build-hrx.yml
@@ -16,18 +16,56 @@ concurrency:
 
 jobs:
   hrx-build:
-    name: ubuntu-latest
-    runs-on: ubuntu-latest
+    name: ${{ matrix.name }} (${{ matrix.gpu_target }})
+    strategy:
+      # Per-arch failures are independent; keep both signals.
+      fail-fast: false
+      matrix:
+        include:
+          - name: gfx1151_strix-halo
+            gpu_target: gfx1151
+            runs_on: linux-gfx1151-gpu-rocm
+            extra_rocm_artifacts: rocwmma_dev_gfx1151
+          - name: gfx1201_9070
+            gpu_target: gfx1201
+            runs_on: linux-gfx120X-gpu-rocm
+            extra_rocm_artifacts: rocwmma_dev_gfx120X-all
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 60
+    defaults:
+      run:
+        # The container default is sh; the bench scripts require bash.
+        shell: bash
+    # The self-hosted ROCm runners require jobs to run in a container; plain
+    # run steps fail in the runner-controller's direct-execution hook.
+    # Image and options mirror TheRock CI
+    # (build_tools/github_actions/fetch_test_configurations.py).
+    container:
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26
+      options: >-
+        --ipc host
+        --user 0:0
+        --ulimit memlock=-1:-1
+        --security-opt seccomp=unconfined
+        --group-add video
+        --device /dev/kfd
+        --device /dev/dri
+        --group-add 993
+        --group-add 992
+        --group-add 110
+        --env-file /etc/podinfo/gha-gpu-isolation-settings
     env:
       HRX_WORK_DIR: ${{ github.workspace }}
       # Public location for bench tooling (rsuderman/llamacpp_ci and fork
       # AaronStGeorge/llamacpp_ci)
       #TODO: switch to ROCm/llamacpp-hrx-bench once it is open sourced.
       BENCH_REPOSITORY: AaronStGeorge/llamacpp_ci
-      BENCH_REF: 'main'
+      #TODO: restore to main once p066-multi-arch-ci merges in the bench repo.
+      BENCH_REF: 'p066-multi-arch-ci'
       BENCH_DIR: ${{ github.workspace }}/bench
       LLAMA_SRC_DIR: ${{ github.workspace }}/llama-src
-      HRX_ARTIFACT_SET: 'core-with-upstream-hip'
+      HRX_EXTRA_ROCM_ARTIFACTS: ${{ matrix.extra_rocm_artifacts }}
+      GGML_HRX_AMDGPU_TARGETS: ${{ matrix.gpu_target }}
       CCACHE_COMPILERCHECK: content
 
     steps:
@@ -49,7 +87,7 @@ jobs:
       - name: ccache
         uses: ggml-org/ccache-action@v1.2.21
         with:
-          key: ubuntu-latest-${{ env.HRX_ARTIFACT_SET }}
+          key: ${{ matrix.gpu_target }}
           evict-old-files: 1d
           save: ${{ github.event_name == 'pull_request' }}
 
@@ -63,33 +101,37 @@ jobs:
         run: "${BENCH_DIR}/scripts/hrx/build-hrx.sh"
 
       - name: Validate HRX
+        # hrx-info has been observed hanging on some runners; fail fast.
+        timeout-minutes: 5
         run: "${BENCH_DIR}/scripts/hrx/validate-hrx.sh"
 
       - name: Build llama.cpp with HRX
         run: "${BENCH_DIR}/scripts/hrx/build-llama-hrx.sh"
 
-      - name: Run sample MUL_MAT correctness config on CPU
+      - name: Run sample MUL_MAT correctness config on HRX
+        timeout-minutes: 15
         run: |
           . "${BENCH_DIR}/scripts/hrx/env.sh"
           "${BENCH_DIR}/tools/run-op-test.py" \
             --test-backend-ops "${LLAMA_BUILD_DIR}/bin/test-backend-ops" \
             --test-file "${BENCH_DIR}/benchmark-configs/test/mul_mat_f16.txt" \
             --op MUL_MAT \
-            --backend CPU \
-            --output benchmark-results/sample-mul-mat-f16-cpu-test.jsonl
+            --backend HRX0 \
+            --output benchmark-results/sample-mul-mat-f16-hrx-test.jsonl
 
-      - name: Run sample MUL_MAT benchmark config on CPU
+      - name: Run sample MUL_MAT benchmark config on HRX
+        timeout-minutes: 15
         run: |
           . "${BENCH_DIR}/scripts/hrx/env.sh"
           "${BENCH_DIR}/tools/run-op-perf.py" \
             --test-backend-ops "${LLAMA_BUILD_DIR}/bin/test-backend-ops" \
             --test-file "${BENCH_DIR}/benchmark-configs/test/mul_mat_f16.txt" \
             --op MUL_MAT \
-            --backend CPU \
-            --output benchmark-results/sample-mul-mat-f16-cpu-perf.jsonl
+            --backend HRX0 \
+            --output benchmark-results/sample-mul-mat-f16-hrx-perf.jsonl
 
-      - name: Upload CPU benchmark results
+      - name: Upload benchmark results
         uses: actions/upload-artifact@v5
         with:
-          name: cpu-benchmark-results
+          name: benchmark-results-${{ matrix.name }}
           path: benchmark-results/

--- a/.github/workflows/build-riscv.yml
+++ b/.github/workflows/build-riscv.yml
@@ -16,7 +16,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-riscv.yml',

--- a/.github/workflows/build-riscv.yml
+++ b/.github/workflows/build-riscv.yml
@@ -16,6 +16,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-riscv.yml',

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -24,7 +24,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-self-hosted.yml',

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -24,6 +24,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-self-hosted.yml',

--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -18,6 +18,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-vulkan.yml',

--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -18,7 +18,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build-vulkan.yml',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build.yml',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/build.yml',

--- a/.github/workflows/check-vendor.yml
+++ b/.github/workflows/check-vendor.yml
@@ -11,6 +11,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       'vendor/**',

--- a/.github/workflows/check-vendor.yml
+++ b/.github/workflows/check-vendor.yml
@@ -11,7 +11,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       'vendor/**',

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     paths:
       - .github/workflows/copilot-setup-steps.yml
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,9 +5,11 @@ name: "Copilot Setup Steps"
 on:
   workflow_dispatch:
   push:
+    branches-ignore: ['hrx-integration']
     paths:
       - .github/workflows/copilot-setup-steps.yml
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     paths:
       - .github/workflows/copilot-setup-steps.yml
 

--- a/.github/workflows/hip-quality-check.yml
+++ b/.github/workflows/hip-quality-check.yml
@@ -13,7 +13,7 @@ on:
     ]
 
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/hip-quality-check.yml',

--- a/.github/workflows/hip-quality-check.yml
+++ b/.github/workflows/hip-quality-check.yml
@@ -13,6 +13,7 @@ on:
     ]
 
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/hip-quality-check.yml',

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,7 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  pull_request_target:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
 
 jobs:
   labeler:

--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -2,10 +2,12 @@ name: Check Pre-Tokenizer Hashes
 
 on:
     push:
+        branches-ignore: ['hrx-integration']
         paths:
             - 'convert_hf_to_gguf.py'
             - 'convert_hf_to_gguf_update.py'
     pull_request:
+        branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
         paths:
             - 'convert_hf_to_gguf.py'
             - 'convert_hf_to_gguf_update.py'

--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -7,7 +7,7 @@ on:
             - 'convert_hf_to_gguf.py'
             - 'convert_hf_to_gguf_update.py'
     pull_request:
-        branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+        branches-ignore: ['hrx-integration']
         paths:
             - 'convert_hf_to_gguf.py'
             - 'convert_hf_to_gguf_update.py'

--- a/.github/workflows/python-check-requirements.yml
+++ b/.github/workflows/python-check-requirements.yml
@@ -2,12 +2,14 @@ name: Python check requirements.txt
 
 on:
   push:
+    branches-ignore: ['hrx-integration']
     paths:
       - '.github/workflows/python-check-requirements.yml'
       - 'scripts/check-requirements.sh'
       - 'convert*.py'
       - '**/requirements*.txt'
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     paths:
       - '.github/workflows/python-check-requirements.yml'
       - 'scripts/check-requirements.sh'

--- a/.github/workflows/python-check-requirements.yml
+++ b/.github/workflows/python-check-requirements.yml
@@ -9,7 +9,7 @@ on:
       - 'convert*.py'
       - '**/requirements*.txt'
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     paths:
       - '.github/workflows/python-check-requirements.yml'
       - 'scripts/check-requirements.sh'

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -9,7 +9,7 @@ on:
       '**/*.py'
     ]
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/python-lint.yml',

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -9,6 +9,7 @@ on:
       '**/*.py'
     ]
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/python-lint.yml',

--- a/.github/workflows/python-type-check.yml
+++ b/.github/workflows/python-type-check.yml
@@ -2,6 +2,7 @@ name: Python Type-Check
 
 on:
   push:
+    branches-ignore: ['hrx-integration']
     paths:
       - '.github/workflows/python-type-check.yml'
       - 'ty.toml'
@@ -9,6 +10,7 @@ on:
       - '**/requirements*.txt'
       # - 'pyrightconfig.json'
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     paths:
       - '.github/workflows/python-type-check.yml'
       - 'ty.toml'

--- a/.github/workflows/python-type-check.yml
+++ b/.github/workflows/python-type-check.yml
@@ -10,7 +10,7 @@ on:
       - '**/requirements*.txt'
       # - 'pyrightconfig.json'
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     paths:
       - '.github/workflows/python-type-check.yml'
       - 'ty.toml'

--- a/.github/workflows/server-webui.yml
+++ b/.github/workflows/server-webui.yml
@@ -17,7 +17,7 @@ on:
       'tools/server/public/**'
     ]
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/server-webui.yml',

--- a/.github/workflows/server-webui.yml
+++ b/.github/workflows/server-webui.yml
@@ -17,6 +17,7 @@ on:
       'tools/server/public/**'
     ]
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/server-webui.yml',

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -28,6 +28,7 @@ on:
       'tools/server/**.*'
     ]
   pull_request:
+    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/server.yml',

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -28,7 +28,7 @@ on:
       'tools/server/**.*'
     ]
   pull_request:
-    branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+    branches-ignore: ['hrx-integration']
     types: [opened, synchronize, reopened]
     paths: [
       '.github/workflows/server.yml',

--- a/.github/workflows/update-ops-docs.yml
+++ b/.github/workflows/update-ops-docs.yml
@@ -8,7 +8,7 @@ on:
             - 'docs/ops/**'
             - 'scripts/create_ops_docs.py'
     pull_request:
-        branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
+        branches-ignore: ['hrx-integration']
         paths:
             - 'docs/ops.md'
             - 'docs/ops/**'

--- a/.github/workflows/update-ops-docs.yml
+++ b/.github/workflows/update-ops-docs.yml
@@ -2,11 +2,13 @@ name: Update Operations Documentation
 
 on:
     push:
+        branches-ignore: ['hrx-integration']
         paths:
             - 'docs/ops.md'
             - 'docs/ops/**'
             - 'scripts/create_ops_docs.py'
     pull_request:
+        branches-ignore: ['hrx-integration']  # fork: hrx-integration runs only build-hrx.yml
         paths:
             - 'docs/ops.md'
             - 'docs/ops/**'

--- a/ggml/src/ggml-hrx/ggml-hrx.cpp
+++ b/ggml/src/ggml-hrx/ggml-hrx.cpp
@@ -2521,7 +2521,7 @@ static bool ggml_backend_hrx_load_catalog_provider(
                         executable, export_ordinal, &export_info)) &&
                     export_info.binding_count == entry->binding_count &&
                     export_info.parameter_count == entry->parameter_count &&
-                    export_info.constant_count * sizeof(uint32_t) == entry->constants_size;
+                    export_info.constant_byte_length == entry->constants_size;
     if (!ok) {
         GGML_LOG_WARN(
             "%s: HRX catalog kernel %s has unsupported ABI "
@@ -2530,7 +2530,7 @@ static bool ggml_backend_hrx_load_catalog_provider(
             entry->name,
             export_info.binding_count,
             entry->binding_count,
-            export_info.constant_count,
+            export_info.constant_byte_length,
             entry->constants_size,
             export_info.parameter_count,
             entry->parameter_count,


### PR DESCRIPTION
Replaces the ubuntu-latest CPU job in `build-hrx.yml` with a matrix on the self-hosted ROCm runners (`linux-gfx1151-gpu-rocm`, `linux-gfx120X-gpu-rocm`), building for the runner's gfx target and running the sample MUL_MAT correctness/perf configs on the `HRX0` backend. Per-arch `rocwmma` dev artifacts are fetched (`rocwmma_dev_gfx1151`, `rocwmma_dev_gfx120X-all`; both verified present in pinned TheRock run 25753625030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)