### PR TITLE
Add mmq device table for RDNA3.5

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -140,6 +140,9 @@ static constexpr __device__ int get_mmq_x_max_device() {
 }
 
 static int get_mmq_y_host(const int cc) {
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc)) {
+        return 64;
+    }
     return GGML_CUDA_CC_IS_AMD(cc) ? (GGML_CUDA_CC_IS_RDNA1(cc) ? 64 : 128) :
         ((GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA) ? 128 : 64);
 }
@@ -155,7 +158,9 @@ if (type == GGML_TYPE_NVFP4 || type == GGML_TYPE_MXFP4) {
 
 static constexpr __device__ int get_mmq_y_device() {
 #if defined(GGML_USE_HIP)
-#if defined(RDNA1)
+#if defined(RDNA3_5)
+    return 64;
+#elif defined(RDNA1)
     return 64;
 #else
     return 128;
@@ -296,6 +301,9 @@ static constexpr __device__ int mmq_get_granularity_device(const int /*mmq_x*/) 
 
 #if defined(GGML_USE_HIP)
 static int mmq_get_nwarps_host(const int cc, const int warp_size) {
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc)) {
+        return 4;
+    }
     return amd_mfma_available(cc) ? 8 : 256/warp_size;
 }
 #else
@@ -305,7 +313,9 @@ static int mmq_get_nwarps_host(const int /*cc*/, const int warp_size) {
 #endif // (GGML_USE_HIP)
 
 static constexpr __device__ int mmq_get_nwarps_device() {
-#if defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+#if defined(RDNA3_5)
+    return 4;
+#elif defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 8;
 #else
     return 256/ggml_cuda_get_physical_warp_size();


### PR DESCRIPTION
## Overview

Add mmq device table for RDNA3.5.

  - get_mmq_y_host — returns 64 for RDNA3.5 (host).                                                                                                             
  - get_mmq_y_device — returns 64 under #if defined(RDNA3_5) (device).                                                                                          
  - mmq_get_nwarps_host — returns 4 for RDNA3.5 (host).                                                                                                         
  - mmq_get_nwarps_device — returns 4 under #if defined(RDNA3_5) (device).   

## Additional information

27 models including both dense and moe (gemma4_26b_a4b, qwen35_35b_a3b, qwen3_30b_a3b), from small (qwen25_05b, smollm2_17b, gemma2_2b) to large (qwen3_17b) models,  all Q4_K_M were tests on gfx1151. Prefill at n=128 has the most performance boost, many models see +14% to +18% improvement. At longer sequences (512–4096), most models see a consistent +2% to +8% prefill improvement. It changes the mmq nwarps and mmq_y_max which do not impact mmvq's performance. Decode is essentially neutral, no regression.

PPL check has been performed, All 27 models are bit-identical. 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I used AI to do investigation. 

>
