### PR TITLE
ggml-cuda: one-time K-padded f16 dequantization for prefill GEMMs

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1755,15 +1755,45 @@ static void ggml_cuda_op_mul_mat_cublas(
         to_fp32_cuda(dst_bf16.get(), dst_dd_i, row_diff*src1_ncols, stream);
     } else if (fast_fp16_hardware_available(cc) && use_fp16) {
         // convert src0 and src1 to fp16, multiply as fp16, convert dst to fp32
-        ggml_cuda_pool_alloc<half> src0_as_f16(ctx.pool(id));
-        if (src0->type != GGML_TYPE_F16) {
+        int64_t lda_use = lda_f16;
+        const half * src0_ptr = nullptr;
+        ggml_cuda_pool_alloc<half> src0_as_f16(ctx.pool(id)); // fallback (non-cached) storage
+        if (src0->type == GGML_TYPE_F16) {
+            src0_ptr = (const half *) src0_dd_i;
+        } else {
             const to_fp16_cuda_t to_fp16_cuda = ggml_get_to_fp16_cuda(src0->type);
             GGML_ASSERT(to_fp16_cuda != nullptr);
-            size_t ne = row_diff*ne00;
-            src0_as_f16.alloc(ne);
-            to_fp16_cuda(src0_dd_i, src0_as_f16.get(), ne, stream);
+            const size_t ne = row_diff*ne00;
+            // GGML_PREFILL_DEQUANT: dequantize the weight ONCE into a persistent K-padded f16 buffer
+            // (+1 cache line, avoids cache-set aliasing) and cache it by weight pointer. Subsequent
+            // calls reuse it, so only the activation convert + GEMM run per call.
+            static const int deq_pad = getenv("GGML_PREFILL_DEQUANT") ? (GGML_CUDA_CACHE_LINE/(int)sizeof(half)) : 0;
+            const bool do_cache = deq_pad && (ne00 % (GGML_CUDA_ROW_ALIAS_STRIDE/(int)sizeof(half)) == 0);
+            if (do_cache) {
+                const int64_t lda_pad = ne00 + deq_pad;
+                static std::mutex cache_mtx;
+                static std::unordered_map<const void *, std::pair<half *, int64_t>> cache;
+                std::lock_guard<std::mutex> lk(cache_mtx);
+                auto it = cache.find(src0_dd_i);
+                if (it == cache.end()) {
+                    half * buf = nullptr;
+                    CUDA_CHECK(cudaMalloc(&buf, (size_t)row_diff*lda_pad*sizeof(half)));
+                    ggml_cuda_pool_alloc<half> tmp(ctx.pool(id), ne);
+                    to_fp16_cuda(src0_dd_i, tmp.get(), ne, stream);
+                    CUDA_CHECK(cudaMemcpy2DAsync(buf, lda_pad*sizeof(half),
+                                                 tmp.get(), ne00*sizeof(half),
+                                                 ne00*sizeof(half), row_diff, cudaMemcpyDeviceToDevice, stream));
+                    CUDA_CHECK(cudaStreamSynchronize(stream)); // finish before tmp is recycled (one-time)
+                    it = cache.emplace(src0_dd_i, std::make_pair(buf, lda_pad)).first;
+                }
+                src0_ptr = it->second.first;
+                lda_use  = it->second.second;
+            } else {
+                src0_as_f16.alloc(ne);
+                to_fp16_cuda(src0_dd_i, src0_as_f16.get(), ne, stream);
+                src0_ptr = src0_as_f16.get();
+            }
         }
-        const half * src0_ptr = src0->type == GGML_TYPE_F16 ? (const half *) src0_dd_i : src0_as_f16.get();
 
         ggml_cuda_pool_alloc<half> src1_as_f16(ctx.pool(id));
         if (src1->type != GGML_TYPE_F16) {
@@ -1789,7 +1819,7 @@ static void ggml_cuda_op_mul_mat_cublas(
             CUBLAS_CHECK(
                 cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
                         row_diff, src1_ncols, ne10,
-                        &alpha, src0_ptr,  CUDA_R_16F, lda_f16,
+                        &alpha, src0_ptr,  CUDA_R_16F, lda_use,
                                 src1_ptr,  CUDA_R_16F, ne10,
                         &beta,   dst_dd_i, CUDA_R_32F, ldc,
                         CUBLAS_COMPUTE_32F,
@@ -1803,7 +1833,7 @@ static void ggml_cuda_op_mul_mat_cublas(
             CUBLAS_CHECK(
                 cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
                         row_diff, src1_ncols, ne10,
-                        &alpha_f16, src0_ptr,      CUDA_R_16F, lda_f16,
+                        &alpha_f16, src0_ptr,      CUDA_R_16F, lda_use,
                                     src1_ptr,      CUDA_R_16F, ne10,
                         &beta_f16,  dst_f16.get(), CUDA_R_16F, ldc,
                         CUBLAS_COMPUTE_16F,
@@ -2654,6 +2684,21 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
         use_mul_mat_vec_f       = use_mul_mat_vec_f         && ggml_cuda_should_use_mmvf(src0->type, cc, src0->ne, src0->nb, src1->ne[1]);
         use_mul_mat_vec_q       = use_mul_mat_vec_q         && ggml_cuda_should_use_mmvq(src0->type, cc, src1->ne[1]);
         any_gpus_with_slow_fp16 = any_gpus_with_slow_fp16   || !fast_fp16_hardware_available(cc);
+    }
+
+    // GGML_PREFILL_DEQUANT=<min_tokens>: for large-batch (prefill) quantized GEMMs, force the
+    // dequantize-to-f16 + hipBLAS path (K-padded, see op_mul_mat_cublas) instead of MMQ.
+    {
+        static const int prefill_dequant_min = [] {
+            const char * env = getenv("GGML_PREFILL_DEQUANT");
+            if (env == nullptr) return 0;
+            const int v = atoi(env);
+            return v > 1 ? v : 32;
+        }();
+        if (prefill_dequant_min > 0 && ggml_is_quantized(src0->type) && src1->ne[1] >= prefill_dequant_min) {
+            use_mul_mat_q     = false;
+            use_mul_mat_vec_q = false;
+        }
     }
 
     // debug helpers


### PR DESCRIPTION
## Summary

This PR adds an opt-in path that, for large-batch (prefill) quantized dense matmuls, dequantizes the weight to f16 once and runs the GEMM through hipBLAS instead of MMQ. The weight is dequantized a single time into a persistent, K-padded f16 buffer that is cached and reused across calls, so subsequent prefill steps pay only the activation conversion and the GEMM itself. Decode (small batch) is left entirely on the existing MMQ/MMVQ path. The feature is off by default and enabled with the `GGML_PREFILL_DEQUANT` environment variable.

## Motivation

On RDNA3.5 (gfx1151) the dense q8_0 attention projections in prefill run through MMQ (int8 WMMA) at roughly 61% of the f16 WMMA roofline. Roofline profiling and standalone hipBLAS microbenchmarks showed that the same GEMM, run as f16 through hipBLAS with a cache-line-padded K dimension, reaches roughly 80% of that roofline and is faster at the kernel level for batch sizes at and above ~512 tokens. The catch is that a naive dequantize-on-every-call approach loses this advantage because the per-call weight dequantization (q8_0 to f16) costs more than the GEMM saves. This PR removes that tax by dequantizing each weight exactly once and caching the padded f16 result.

## How it works

Two changes, both confined to `ggml/src/ggml-cuda/ggml-cuda.cu`. First, in `ggml_cuda_mul_mat`, when `GGML_PREFILL_DEQUANT=<min_tokens>` is set and the matmul is a quantized weight with `src1->ne[1] >= min_tokens` (default 32), MMQ and MMVQ are disabled for that op so dispatch falls through to `ggml_cuda_op_mul_mat_cublas`. Second, in `ggml_cuda_op_mul_mat_cublas`, the f16 branch dequantizes a quantized src0 once into a persistent buffer whose row stride is padded by one cache line (`GGML_CUDA_CACHE_LINE`), which avoids the cache-set aliasing that otherwise halves hipBLAS throughput when the packed row size is a multiple of `GGML_CUDA_ROW_ALIAS_STRIDE`. The padded buffer is stored in a static map keyed by the weight device pointer; on a cache hit the stored pointer and padded leading dimension are used directly and no dequantization is performed. The GEMM leading dimension (`lda`) is switched from the packed `ne00` to the padded stride for both the COMPUTE_32F and COMPUTE_16F code paths.

## Performance

Measured on gfx1151 (Strix Halo, Qwen3.6-35B-A3B UD-Q4_K_M) with the roofline profiler and llama-bench. At the kernel level the padded f16 hipBLAS GEMM for the largest dense projection (q8_0 [2048, 8192], M=512) reaches about 34.7 TFLOPS (80.7% of the 43 TFLOPS f16 WMMA roofline) versus MMQ at about 26 TFLOPS (61%). The pure-prefill throughput improvement is roughly 3-5% at pp512 and above when combined with `ROCBLAS_USE_HIPBLASLT=1`. End-to-end (combined prefill plus decode) the gain is small and workload-dependent: decode is unaffected and dilutes the prefill improvement, batch sizes at or below 128 tokens are below the crossover where MMQ is still faster, and the dense projections are only a fraction of prefill time since the MoE expert GEMMs remain on MMQ. On this thermally noisy APU the e2e delta at pp128+tg128 and pp4096+tg128 is within run-to-run variance. The feature is therefore most useful for prefill-heavy, low-generation workloads (long-context prompt processing, summarization, batch scoring).

## Usage

Enable at runtime with `GGML_PREFILL_DEQUANT=32` (the value is the minimum token count that triggers the path; any value greater than 1 is used verbatim, otherwise it defaults to 32). Pair it with `ROCBLAS_USE_HIPBLASLT=1` so the underlying `cublasGemmEx` call is served by hipBLASLt, whose default heuristic picks a good f32-accumulate WMMA kernel for this case; without it rocBLAS may select a slower solution. When the variable is unset the code path is identical to before.

## Correctness

The padded f16 layout is bit-identical to the unpadded f16 layout (the padding only changes the row stride, not the data), and the f16 GEMM result matches MMQ within quantization error (about 1e-3 relative). Greedy generation output was verified to match the baseline for the cases tested.