### PR TITLE
ci(gfx11): track latest ROCm nightly (unpin 7.14.0a20260608)

### DIFF
--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -10,24 +10,24 @@ on:
       rocm_version:
         description: 'ROCm version to use (e.g., 7.14.0a20260608) or "latest" to auto-detect'
         required: false
-        default: '7.14.0a20260608'
+        default: 'latest'
       create_release:
         description: 'Publish a dated GitHub Release (b<YYYYMMDD>) with the built binaries. Set true only for the nightly dispatch.'
         required: false
         default: 'false'
 
-# Pinned to ROCm 7.14.0a20260608: last known-good nightly (libhsa-runtime64 build
-# d34cbb6409). The 7.14.0a20260609 and newer nightlies regressed libhsa-runtime64
-# (build 1b2a555677), which segfaults in GpuAgent::InitDma on the gfx115x runners.
-# See https://github.com/ROCm/TheRock/issues/5763. Pass rocm_version=latest manually
-# to track the newest nightly.
+# Tracks the latest multiarch ROCm nightly (auto-detected). The earlier pin to
+# 7.14.0a20260608 worked around a libhsa-runtime64 regression (build 1b2a555677)
+# that segfaulted in GpuAgent::InitDma on the gfx115x runners; that issue
+# (https://github.com/ROCm/TheRock/issues/5763) is now resolved. Pass an explicit
+# rocm_version (e.g. 7.14.0a20260608) to pin a specific nightly again.
 #
 # Nightly is driven externally (GitHub cron only fires from the default branch).
 # On a host you control, with `gh` authenticated (token scope: repo + workflow):
-#   0 13 * * *  gh workflow run build-gfx11-rocm.yml --repo ROCm/llama.cpp --ref gfx11 -f rocm_version=7.14.0a20260608
+#   0 13 * * *  gh workflow run build-gfx11-rocm.yml --repo ROCm/llama.cpp --ref gfx11 -f rocm_version=latest
 
 env:
-  ROCM_VERSION: ${{ github.event.inputs.rocm_version || '7.14.0a20260608' }}
+  ROCM_VERSION: ${{ github.event.inputs.rocm_version || 'latest' }}
 
 jobs:
   build-ubuntu:


### PR DESCRIPTION
The TheRock libhsa-runtime64 InitDma regression (ROCm/TheRock#5763) that motivated pinning to 7.14.0a20260608 is now resolved. The gfx11 build now defaults ROCM_VERSION to the latest auto-detected multiarch nightly; pass an explicit rocm_version input to pin a specific nightly again.

Validated locally: the latest nightly (7.15.0a20260707) compiles llama.cpp for gfx1151 and runs on-device (Radeon 8060S / gfx1151) with no InitDma segfault.