### PR TITLE
ggml-cuda: size MMQ tile to MoE tokens-per-expert

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -4076,6 +4076,18 @@ void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cuda
     int mmq_x_best  = 0;
     int ntiles_x_best = INT_MAX;
 
+    // ncols_max assumes every token can land in a single tile column range; for MoE that is the
+    // worst case of all tokens routed to one expert, but experts typically receive only
+    // ncols_dst/nchannels_y tokens. Tiling over ~2x that average keeps the common per-expert
+    // tiles filled instead of mostly empty; the 2x covers routing imbalance and larger batches
+    // converge back to ncols_max.
+    // Restricted to RDNA3.5, the only arch this MoE tile sizing was tuned/validated on.
+    int64_t ncols_to_tile = args.ncols_max;
+    if (args.expert_bounds != nullptr && GGML_CUDA_CC_IS_RDNA3_5(cc)) {
+        const int64_t ncols_per_expert = (args.ncols_dst + args.nchannels_y - 1) / args.nchannels_y;
+        ncols_to_tile = 2*ncols_per_expert < args.ncols_max ? 2*ncols_per_expert : args.ncols_max;
+    }
+
     for (int mmq_x = 8; mmq_x <= mmq_x_max && ntiles_x_best > 1; mmq_x += 8) {
         const int granularity = mmq_get_granularity_host(mmq_x, cc);
 
@@ -4083,7 +4095,7 @@ void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cuda
             continue;
         }
 
-        const int ntiles_x = (args.ncols_max + mmq_x - 1) / mmq_x;
+        const int ntiles_x = (ncols_to_tile + mmq_x - 1) / mmq_x;
 
         if (ntiles_x < ntiles_x_best) {
             mmq_x_best = mmq_x;


### PR DESCRIPTION
## What this changes

An MoE prefill optimization for the MMQ (quantized matmul) path. For `MUL_MAT_ID`, `mul_mat_q_case` picks the tile width (`mmq_x`) by tiling over `ncols_max`, which assumes every token can land in a single tile column range - the worst case of all tokens routed to one expert. In practice each expert receives only about `ncols_dst / nchannels_y` tokens, so at large `ncols_max` the selection lands on wide tiles (e.g. `mmq_x=128`) that are mostly empty per expert.

This computes the tile width from `~2x` the average tokens-per-expert instead: when `expert_bounds != nullptr`, `ncols_to_tile = min(2 * ceil(ncols_dst / nchannels_y), ncols_max)`. The `2x` covers routing imbalance, and larger batches converge back to `ncols_max`, so dense (non-MoE) matmuls are unaffected. The heuristic is restricted to RDNA3.5 (`GGML_CUDA_CC_IS_RDNA3_5`), the only architecture it has been tuned and validated on.

## Benchmarks

Measured on gfx1151 (Radeon 8060S), Qwen3.6-35B-A3B Q4_K_M, `-ngl 999 -r 1`, built with `-DGGML_HIP_ROCWMMA_FATTN=OFF`. Baseline is `gfx11` at the same commit base.

| test | baseline t/s | this PR t/s | delta |
| ---- | -----------: | ----------: | ----: |
| pp128  | 549.01 | 1051.11 | +91.5% |
| pp1024 | 1133.77 | 1580.15 | +39.4% |
| tg128  | 53.31 | 53.14 | -0.3% (noise) |

Prefill throughput improves substantially; decode is untouched (the change only affects batched-matmul tiling). `-r 1` has no error bars, but the prefill deltas are far outside run-to-run noise.
