### PR TITLE
ggml-cuda: tune D=256 tile flash-attn config for RDNA3.5

### DIFF
--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -309,8 +309,19 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_am
     return 0;
 }
 
+static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_amd_rdna3_5(const int DKQ, const int DV, const int ncols) {
+    // With rocWMMA FlashAttention off, D=256 prefill runs on the tile kernel; on RDNA3.5 a smaller
+    // K tile with higher occupancy is faster than the shared RDNA values. Other cases fall back.
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256, 4, 64, 64)
+
+    return ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
+}
+
 static __host__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const int DV, const int ncols, const int cc) {
     if (GGML_CUDA_CC_IS_AMD(cc)) {
+        if (GGML_CUDA_CC_IS_RDNA3_5(cc)) {
+            return ggml_cuda_fattn_tile_get_config_amd_rdna3_5(DKQ, DV, ncols);
+        }
         if (GGML_CUDA_CC_IS_RDNA(cc)) {
             return ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
         }
@@ -324,11 +335,13 @@ static __host__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const in
 
 static constexpr __device__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const int DV, const int ncols) {
 #ifdef GGML_USE_HIP
-#ifdef RDNA
+#ifdef RDNA3_5
+    return ggml_cuda_fattn_tile_get_config_amd_rdna3_5(DKQ, DV, ncols);
+#elif defined(RDNA)
     return ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
 #else
     return ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
-#endif // RDNA
+#endif // RDNA3_5
 #else
 #ifdef FAST_FP16_AVAILABLE
     return ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);


### PR DESCRIPTION
## What this changes

A tile flash-attn tuning for RDNA3.5. With rocWMMA FlashAttention off (`-DGGML_HIP_ROCWMMA_FATTN=OFF`), D=256 prefill runs on the tile kernel, and the shared RDNA tile config is not optimal on RDNA3.5 for the D=256, ncols=32 case. This adds `ggml_cuda_fattn_tile_get_config_amd_rdna3_5`, which overrides just that row with a smaller K tile and higher occupancy (nbatch_K 128->64, occupancy 3->4) and falls back to the shared RDNA table for every other case.

Selection is matched consistently on both sides: the host path checks `GGML_CUDA_CC_IS_RDNA3_5(cc)` before the generic RDNA branch, and the device path uses the `RDNA3_5` macro ahead of `RDNA`. Only RDNA3.5 sees the new config; all other architectures are unchanged.

## Benchmarks

Measured on gfx1151 (Radeon 8060S), Qwen3.6-35B-A3B Q4_K_M, `-ngl 999 -r 1`, built with `-DGGML_HIP_ROCWMMA_FATTN=OFF`. Baseline is `gfx11` at the same commit base.

| test | baseline t/s | this PR t/s | delta |
| ---- | -----------: | ----------: | ----: |
| pp128  | 549.01 | 563.88 | +2.7% |
| pp1024 | 1133.77 | 1137.63 | +0.3% (noise) |
| tg128  | 53.31 | 53.28 | -0.1% (noise) |

On this model the effect is small - Qwen3.6-35B-A3B does not lean heavily on the D=256 tile path - so most of the movement is within run-to-run noise at `-r 1`. The change is a targeted config override that only affects the D=256 tile kernel, which is exercised more directly by models with a 256-wide head dim.
