### PR TITLE
mtmd-cli: reset roofline profiler after warmup prefill

### DIFF
--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -134,6 +134,13 @@ if (LLAMA_BUILD_TOOLS)
     target_link_libraries  (${TARGET} PRIVATE llama-common mtmd Threads::Threads)
     target_compile_features(${TARGET} PRIVATE cxx_std_17)
 
+    # Compile in the post-warmup roofline reset only when the HIP profiler is built
+    # (ggml-cuda-roofline.cpp, linked via ggml-hip). No-op in every other build.
+    if (GGML_HIP_ROOFLINE)
+        target_compile_definitions(${TARGET} PRIVATE GGML_HIP_ROOFLINE)
+        target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../ggml/src/ggml-cuda)
+    endif()
+
     # mtmd-debug tool
     add_executable(llama-mtmd-debug debug/mtmd-debug.cpp)
     set_target_properties(llama-mtmd-debug PROPERTIES OUTPUT_NAME llama-mtmd-debug)

--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -10,6 +10,13 @@
 #include "mtmd.h"
 #include "mtmd-helper.h"
 
+// Optional per-op roofline profiler (HIP build with GGML_HIP_ROOFLINE). Used to
+// discard warmup so the report covers only the measured prefill. Compiled out
+// otherwise. See ggml/src/ggml-cuda/ggml-cuda-roofline.cpp.
+#ifdef GGML_HIP_ROOFLINE
+#include "ggml-cuda-roofline.h"
+#endif
+
 #include <vector>
 #include <limits.h>
 #include <cinttypes>
@@ -453,6 +460,11 @@ int main(int argc, char ** argv) {
                 return 1; // error is already printed by libmtmd
             }
         }
+        // Discard warmup from the per-op roofline profiler so the report covers
+        // only the measured prefill below. Compiled out unless GGML_HIP_ROOFLINE.
+#ifdef GGML_HIP_ROOFLINE
+        ggml_cuda_roofline_reset();
+#endif
         if (eval_message(ctx, msg)) {
             return 1;
         }


### PR DESCRIPTION
## Summary
This PR wires the existing per-op HIP roofline profiler into `llama-mtmd-cli` so VLM prefill can produce a clean, prefill-only artifact. After the multimodal warmup encode pass completes, `ggml_cuda_roofline_reset()` discards everything recorded during warmup; the subsequent measured prefill (vision encoder + text prompt) is what lands in the `GGML_ROOFLINE_OUT` report on exit. The change mirrors the post-warmup reset already used in `llama-bench` for text models.
## Motivation
The roofline profiler added in #33 is already usable for text prefill through `llama-bench` (`-p N -n 0 -r 1` with `GGML_ROOFLINE_OUT` set). VLM models are exercised through `llama-mtmd-cli` (or `llama-server`), and mtmd performs its own warmup encode during initialization. Without a reset at the prefill boundary, the atexit report would blend warmup vision-encoder ops with the measured prefill, making the artifact unusable for the prefill roofline KPI in rocm-scripts (`tools/generate_llamacpp_ttft_from_artifacts.py` expects a prefill-only slice).
## What changed
`tools/mtmd/mtmd-cli.cpp` includes `ggml-cuda-roofline.h` and calls `ggml_cuda_roofline_reset()` immediately after the warmup message is evaluated and before the measured prefill `eval_message` runs. `tools/mtmd/CMakeLists.txt` defines `GGML_HIP_ROOFLINE` for the `llama-mtmd-cli` target and adds the `ggml-cuda` include path when the HIP roofline option is enabled at build time, matching the `llama-bench` wiring. Both the include and the reset call are behind `#ifdef GGML_HIP_ROOFLINE`, so non-roofline builds are unchanged.
## Usage
Build with `-DGGML_HIP=ON -DGGML_HIP_ROOFLINE=ON`, then run: `GGML_ROOFLINE_OUT=/tmp/vlm-roofline.json ./build/bin/llama-mtmd-cli -m model.gguf --mmproj mmproj.gguf --image img.jpg -p "describe this" -n 0`. The JSON written on exit should cover the measured prefill only (vision encode + text prompt), with warmup ops excluded.
