### PR TITLE
ci(gfx11): bundle librocprofiler-sdk for roofline; add roofline input

### DIFF
--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -270,8 +270,6 @@ jobs:
 
         # Copy required ROCm libraries to build directory
         # If artifacts from ROCm or Llama.cpp change, you may need to update this list.
-        # To regenerate the list, run:
-        #   utils/gather_required_libs.py --rocm-dir /opt/rocm --dest-dir build/bin
         echo "Copying required ROCm libraries to build directory..."
         cp -v /opt/rocm/lib/libhipblas.so* "$build_bin_path/" 2>/dev/null || echo "libhipblas.so* not found"
         cp -v /opt/rocm/lib/librocblas.so* "$build_bin_path/" 2>/dev/null || echo "librocblas.so* not found"

--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -15,6 +15,10 @@ on:
         description: 'Publish a dated GitHub Release (b<YYYYMMDD>) with the built binaries. Set true only for the nightly dispatch.'
         required: false
         default: 'false'
+      roofline:
+        description: 'Build with per-op roofline profiling support (GGML_HIP_ROOFLINE) and bundle the profiler libs (librocprofiler-sdk + libdw). Set false for lean builds.'
+        required: false
+        default: 'true'
 
 # Tracks the latest multiarch ROCm nightly (auto-detected). The earlier pin to
 # 7.14.0a20260608 worked around a libhsa-runtime64 regression (build 1b2a555677)
@@ -28,6 +32,9 @@ on:
 
 env:
   ROCM_VERSION: ${{ github.event.inputs.rocm_version || 'latest' }}
+  # Default ON so push/PR/cron (non-dispatch) runs keep roofline, matching prior
+  # always-on behavior; a workflow_dispatch can pass 'false' for a lean build.
+  ROOFLINE: ${{ github.event.inputs.roofline || 'true' }}
 
 jobs:
   build-ubuntu:
@@ -225,7 +232,7 @@ jobs:
           -DGGML_CUDA_FORCE_CUBLAS=OFF \
           -DGGML_RPC=ON \
           -DGGML_HIP_ROCWMMA_FATTN=OFF \
-          -DGGML_HIP_ROOFLINE=ON \
+          -DGGML_HIP_ROOFLINE=${{ env.ROOFLINE == 'true' && 'ON' || 'OFF' }} \
           -DLLAMA_BUILD_BORINGSSL=ON \
           -DGGML_NATIVE=OFF \
           -DGGML_STATIC=OFF \
@@ -274,6 +281,14 @@ jobs:
         cp -v /opt/rocm/lib/libhipblaslt.so* "$build_bin_path/" 2>/dev/null || echo "libhipblaslt.so* not found"
         cp -v /opt/rocm/lib/rocm_sysdeps/lib/librocm_sysdeps_liblzma.so* "$build_bin_path/" 2>/dev/null || echo "librocm_sysdeps_liblzma.so* not found"
         cp -v /opt/rocm/lib/librocprofiler-register.so* "$build_bin_path/" 2>/dev/null || echo "librocprofiler-register.so* not found"
+        # Roofline builds dlopen librocprofiler-sdk.so.1 at runtime (ggml-cuda-roofline.cpp);
+        # the release must ship it plus its one bundle-missing dep libdw
+        # (librocm_sysdeps_dw.so.1 — a hard DT_NEEDED of the sdk lib). The $ORIGIN RPATH
+        # step below lets the dlopen resolve both locally with no LD_LIBRARY_PATH.
+        if [ "${{ env.ROOFLINE }}" = "true" ]; then
+          cp -v /opt/rocm/lib/librocprofiler-sdk.so* "$build_bin_path/" 2>/dev/null || echo "librocprofiler-sdk.so* not found"
+          cp -v /opt/rocm/lib/rocm_sysdeps/lib/librocm_sysdeps_dw.so* "$build_bin_path/" 2>/dev/null || echo "librocm_sysdeps_dw.so* not found"
+        fi
         cp -v /opt/rocm/lib/libamd_comgr.so* "$build_bin_path/" 2>/dev/null || echo "libamd_comgr.so* not found"
         cp -v /opt/rocm/lib/libamd_comgr_loader.so* "$build_bin_path/" 2>/dev/null || echo "libamd_comgr_loader.so* not found"
         cp -v /opt/rocm/lib/libhsa-runtime64.so* "$build_bin_path/" 2>/dev/null || echo "libhsa-runtime64.so* not found"


### PR DESCRIPTION
## Summary
The per-op roofline profiler `dlopen`s `librocprofiler-sdk.so.1` at runtime (`ggml/src/ggml-cuda/ggml-cuda-roofline.cpp`), but the release only bundled `librocprofiler-register.so`. Without the `-sdk` lib on the path the profiler silently no-ops and writes **no artifact** — which is why the downstream `ttft_ms` roofline KPIs never populated.

This PR makes the gfx11 release self-contained for profiling:

- **Bundle `librocprofiler-sdk.so*`** plus its one bundle-missing transitive dep **`librocm_sysdeps_dw.so.1`** (elfutils libdw, a hard `DT_NEEDED` of the sdk lib). Its own deps (`elf`/`z`/`zstd`/`liblzma`/`bz2`) are already bundled. The existing `$ORIGIN` RPATH step lets the runtime `dlopen` resolve both locally with **no `LD_LIBRARY_PATH`**.
- **New `roofline` `workflow_dispatch` input** (default `true`, preserving the prior always-on behavior) gating both `-DGGML_HIP_ROOFLINE` and the extra lib packing, so lean builds can opt out.

## Why
This replaces a runtime workaround on the consumer side (rocm-scripts installed `rocm-sdk-core` into a venv and appended it to `LD_LIBRARY_PATH` just to obtain the `-sdk` lib). A companion rocm-scripts PR removes that workaround once a release built from this change is published.
