### PR TITLE
ci(gfx11): cache HIP builds with ggml-org/ccache-action

### DIFF
--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -198,6 +198,19 @@ jobs:
         echo "Current llama.cpp commit:"
         git log --oneline -1
 
+    - name: ccache
+      # Auto-consumed by the build: llama.cpp's CMake sets ccache as the compile
+      # launcher when GGML_CCACHE is ON (default) and ccache is on PATH, so no
+      # cmake flags are needed. Persists across runs via actions/cache. Nightly
+      # ROCm bumps change the compiler and will miss (expected); incremental
+      # commits on the same ROCm hit. Only write the cache from pushes to gfx11
+      # so PRs read but don't thrash the shared store.
+      uses: ggml-org/ccache-action@v1.2.21
+      with:
+        key: gfx11-rocm-multiarch
+        evict-old-files: 1d
+        save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/gfx11' }}
+
     - name: Build Llama.cpp + ROCm
       run: |
         gpu_targets="${{ env.GPU_TARGETS }}"

--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -208,7 +208,7 @@ jobs:
       uses: ggml-org/ccache-action@v1.2.21
       with:
         key: gfx11-rocm-multiarch
-        evict-old-files: 1d
+        evict-old-files: 7d
         save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/gfx11' }}
 
     - name: Build Llama.cpp + ROCm

--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -198,7 +198,7 @@ jobs:
         echo "Current llama.cpp commit:"
         git log --oneline -1
 
-    - name: ccache
+    - name: Setup ccache
       # Auto-consumed by the build: llama.cpp's CMake sets ccache as the compile
       # launcher when GGML_CCACHE is ON (default) and ccache is on PATH, so no
       # cmake flags are needed. Persists across runs via actions/cache. Nightly


### PR DESCRIPTION
## Summary
- The `build-gfx11-rocm` workflow recompiles all 7 RDNA3/3.5 arches from scratch on every push/PR/dispatch — no build caching today.
- Adds the repo-standard `ggml-org/ccache-action@v1.2.21` (already used by the CUDA/HIP/SYCL/Vulkan/release workflows) before the build step, so object output persists across runs via GitHub's `actions/cache`.
- No cmake changes needed: llama.cpp's CMake sets ccache as the compile launcher automatically when `GGML_CCACHE` is ON (default) and ccache is on `PATH` (`ggml/src/CMakeLists.txt`), wrapping the explicit `/opt/rocm/llvm/bin/clang`.

## Behavior
- Cache **writes** are gated to pushes on `gfx11` (`save: github.event_name == 'push' && github.ref == 'refs/heads/gfx11'`), so PRs read the shared store without thrashing it.
- `evict-old-files: 1d` bounds store growth.
- Nightly ROCm bumps change the compiler and will miss (expected); incremental commits on the same ROCm version hit and rebuild fast.

## Test plan
- [x] CI run on this PR shows the `ccache` step restoring/creating the cache and reports ccache stats at build end.
- [x] Confirm build log shows `ccache found, compilation results will be cached`.
- [ ] Second run on same ROCm version shows a materially faster build (cache hits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)