### PR TITLE
fix: ci(gfx11): disable embedded UI in gfx11 ROCm build

### DIFF
--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -221,6 +221,8 @@ jobs:
           -DGGML_RPC=ON \
           -DGGML_HIP_ROCWMMA_FATTN=OFF \
           -DGGML_HIP_ROOFLINE=ON \
+          -DLLAMA_BUILD_UI=OFF \
+          -DLLAMA_USE_PREBUILT_UI=OFF \
           -DLLAMA_BUILD_BORINGSSL=ON \
           -DGGML_NATIVE=OFF \
           -DGGML_STATIC=OFF \


### PR DESCRIPTION
## Summary
- Disable the embedded Web UI in the gfx11 ROCm build by passing `-DLLAMA_BUILD_UI=OFF` and `-DLLAMA_USE_PREBUILT_UI=OFF` to the cmake configure step in `build-gfx11-rocm.yml`.
- This avoids requiring npm/node and the Hugging Face `dist.tar.gz` download fallback, which was failing the build (the `latest` bucket archive is missing `loading.html`, so `llama-ui-embed` errored out).
- Change is scoped to this CI workflow only; project-wide UI defaults are unchanged.

`llama-server` still builds and links `llama-ui` (empty asset table), so it continues to work over the HTTP API as required by rocm-scripts.

## Test plan
- [x] gfx11 ROCm build completes past the "Provisioning UI assets" step
- [x] `test-gfx` job passes (llama-cli inference on gfx1151)