### PR TITLE
ci(gfx11): install Node.js so llama-ui builds from source

### DIFF
--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -50,6 +50,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Node.js (for llama-ui build from source)
+      uses: actions/setup-node@v6
+      with:
+        node-version: "24"
+
     - name: Clean up existing ROCm directory (safety precaution)
       run: |
         if [ -d "/opt/rocm" ]; then


### PR DESCRIPTION
## Summary

The gfx11 ROCm build started failing at the `Provisioning UI assets` step
(`llama-ui-embed failed (1)` -> `ninja: build stopped`) after the recent
upstream sync (PR #43) pulled in the new SvelteKit web UI and its
`scripts/ui-assets.cmake` provisioning (upstream #22937 moved the prebuilt UI
out of the repo and onto a HuggingFace bucket; #23352 refactored the cmake
build).

`ui-assets.cmake` provisions the embedded web UI in three tiers:
1. pre-built assets checked into `tools/ui/dist/` (not present),
2. **npm build from source** (what upstream CI uses),
3. HuggingFace bucket download (no-npm fallback).

The gfx11 runner has no `npm` (`UI: npm not found, skipping npm build`), so it
fell through to tier 3. There it 404'd on the pinned `b1` bucket (the fork has
no real build number), fell back to the `latest` bucket, and that archive is
out of sync with the checked-out source: it extracted fine (cmake only checks
`index.html`) but `llama-ui-embed` rejected it for a missing required asset
(`loading.html`), which is fatal.

## Fix

Add an `actions/setup-node@v6` step (node 24) before the build, matching what
upstream's own workflows (`release.yml`, `ui-build.yml`) already use. With npm
on PATH the build takes tier 2 and compiles the UI from the checked-out source,
so the assets always match `llama-ui-embed` and there is no dependency on the
HF bucket being in sync. This mirrors upstream behavior and self-heals across
future syncs.

## Test plan

- [x] gfx11 CI `build-ubuntu` job reaches and passes the `Provisioning UI assets` step
- [ ] Build completes and artifacts upload