### PR TITLE
CUDA: route single-column f32 mul_mat through mmvf (transpose-free operand swap)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1759,6 +1759,27 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
         ggml_cuda_mul_mat_vec_f(ctx, src0, src1, nullptr, dst);
         return;
     }
+    // A single-column f32 weight (ne01 == 1) times a wide activation (ne11 > MMVF_MAX_BATCH_SIZE)
+    // misses mmvf above because ne11 is the batch dim, so it falls back to a wasteful f32 cuBLAS
+    // GEMM. The output is a vector, so swapping the operands is transpose-free: the activation
+    // becomes the matrix and the single-column weight the lone F32 vector, with dst reinterpreted
+    // as [ne11, 1].
+    if (ne01 == 1 && ne11 > MMVF_MAX_BATCH_SIZE && ne2 == 1 && ne3 == 1
+            && src0->type == GGML_TYPE_F32
+            && ggml_is_contiguous(src0) && ggml_is_contiguous(src1) && ggml_is_contiguous(dst)
+            && ggml_cuda_should_use_mmvf(src1->type, cc, src1->ne, src1->nb, /*ne11 =*/ 1)) {
+        // dst is [ne00=1, ne11] (one output feature, ne11 tokens); the swapped GEMV instead
+        // produces [ne11, 1] (ne11 rows, a single vector column). Both are the same ne11
+        // contiguous floats, so we only relabel the shape of a shallow copy - no data moves:
+        ggml_tensor dst_vec = *dst;
+        dst_vec.ne[0] = ne11;                    // rows: one result per token
+        dst_vec.ne[1] = 1;                       // a single output vector column
+        dst_vec.nb[1] = dst_vec.nb[0]*ne11;      // nb[0] (element stride) stays; row dim spans ne11
+        dst_vec.nb[2] = dst_vec.nb[1];           // higher dims are 1 -> same stride
+        dst_vec.nb[3] = dst_vec.nb[1];
+        ggml_cuda_mul_mat_vec_f(ctx, src1, src0, nullptr, &dst_vec);
+        return;
+    }
     if (ggml_cuda_should_use_mmf(src0->type, cc, warp_size, src0->ne, src0->nb, ne11, /*mul_mat_id =*/ false)) {
         ggml_cuda_mul_mat_f(ctx, src0, src1, nullptr, dst);
         return;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8555,6 +8555,14 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2880, 32, 2880, {1, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_MXFP4, GGML_TYPE_F32, 2880, 32, 2880, {1, 1}, {1, 1}));
 
+    // single-row f32 weight (m == 1) against a wide activation (n): the second column count sweeps
+    // across MMVF_MAX_BATCH_SIZE (8) so both the direct mmvf path (n <= 8) and the CUDA/HIP
+    // operand-swap GEMV path (n > 8, which would otherwise fall back to an f32 cuBLAS GEMM) are
+    // exercised and checked against the CPU reference. Regression guard for the mul_mat_vec_f swap.
+    for (int64_t n : {1, 7, 8, 9, 16, 128, 512}) {
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F32, GGML_TYPE_F32, 1, n, 2048, {1, 1}, {1, 1}));
+    }
+
 
 #if 0
     {


### PR DESCRIPTION
## Summary

A `mul_mat` of a **single-column f32 weight** (`ne01 == 1`) against a **wide activation** (`ne11 > MMVF_MAX_BATCH_SIZE`) currently misses the in-house `mmvf` vector kernel — because `ne11` (the token count) is the batch dimension and exceeds the 8-column cap — and falls back to an **f32 cuBLAS/rocBLAS GEMM**. That GEMM's 32×32 macro-tile computes just one useful output column out of 32, so it runs at a few percent of peak.

Since the output is a vector, the operands can be swapped **transpose-free**: the activation becomes the matrix and the single-column weight becomes the lone F32 vector, with `dst` reinterpreted as `[ne11, 1]` (same contiguous floats, only `ne`/`nb` relabeled — no data movement). The op then runs as a proper **GEMV** through `ggml_cuda_mul_mat_vec_f`.

The change lives entirely in the `ggml_cuda_mul_mat` dispatch (`ggml/src/ggml-cuda/ggml-cuda.cu`).

## Where this shows up

These single-column f32 weights are exactly the small, unquantized control-signal projections that stay F32 in a GGUF (routers/gates), e.g. the **shared-expert gate** (`ffn_gate_inp_shexp`, `weight f32[n_embd, 1]`) in Qwen3.5/3.6 MoE.

## Measured improvement (Qwen3.6-35B-A3B, gfx1151, prefill pp128)

Per-op (kernel selection is deterministic, so this is the apples-to-apples comparison):

| shared-expert gate (weight f32[2048,1], ×40 layers) | before | after |
| --- | --: | --: |
| kernel | rocBLAS `Cijk_…MT32x32x8` Sgemm | `mul_mat_vec_f` (mmvf) |
| per instance | ~78.4 µs | ~3.8 µs |
| total (40 instances) | ~3135 µs | ~156 µs |

**~20× on this op, ~3.0 ms saved across the prefill.** The router (N=256) and delta-net α/β (N=32) correctly stay on their existing path — they aren't vector-shaped, so the swap doesn't (and shouldn't) apply.

## Correctness / tests

Adds `test-backend-ops` regression cases: `m=1` with `n ∈ {1,7,8,9,16,128,512}` at `k=2048`, sweeping across `MMVF_MAX_BATCH_SIZE` so both the direct mmvf path (`n ≤ 8`) and the new swapped path (`n > 8`) are validated against the CPU reference.

- `test-backend-ops test -o MUL_MAT`: **1141/1141 passed** on the HIP backend; all 7 new cases OK.

## Notes / follow-ups

- The guard requires `src0->type == F32` because the weight lands in mmvf's F32-only vector slot (`ggml_cuda_should_use_mmvf` only validates the matrix operand, so this must be checked explicitly).
- Restricted to plain 2-D matmuls (`ne2 == 1 && ne3 == 1`) and contiguous operands, which keeps the `dst` reinterpretation trivially correct.
- **Cross-backend opportunity:** the same pattern exists in Metal (GEMV↔GEMM via `ne11 > ne11_mm_min`) and Vulkan (`mul_mat_vec_max_cols = 8`). The optimization concept applies there too, but the transpose-free `dst` relabel is a kernel-dispatch detail, so each backend would need its own analogous snippet + measurement — left as follow-up rather than a fragile frontend rewrite.
