### PR TITLE
fix: ci(hip): drop web UI provisioning from hip-quality-check

### DIFF
--- a/.github/workflows/hip-quality-check.yml
+++ b/.github/workflows/hip-quality-check.yml
@@ -65,6 +65,8 @@ jobs:
             -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
             -DGPU_TARGETS=gfx942 \
             -DGGML_HIP=ON \
+            -DLLAMA_BUILD_UI=OFF \
+            -DLLAMA_USE_PREBUILT_UI=OFF \
             -DGGML_HIP_EXPORT_METRICS=Off \
             -DCMAKE_HIP_FLAGS="-Werror -Wno-tautological-compare" \
             -DCMAKE_BUILD_TYPE=Release
@@ -78,6 +80,8 @@ jobs:
             -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
             -DGPU_TARGETS=gfx908 \
             -DGGML_HIP=ON \
+            -DLLAMA_BUILD_UI=OFF \
+            -DLLAMA_USE_PREBUILT_UI=OFF \
             -DGGML_HIP_EXPORT_METRICS=On \
             -DCMAKE_HIP_FLAGS="" \
             -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
The full build pulls in the llama-ui asset target, which fetches a prebuilt UI tarball from HF and validates it; that step can fail independently of the HIP backend this check exists to verify. Build the two configs with -DLLAMA_BUILD_UI=OFF -DLLAMA_USE_PREBUILT_UI=OFF.
