### PR TITLE
ggml-cuda: enable GGML_CUDA_GRAPH_OPT by default on RDNA3.5

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4124,9 +4124,13 @@ static void ggml_backend_cuda_graph_optimize(ggml_backend_t backend, ggml_cgraph
     GGML_UNUSED(cgraph);
 #endif
 
-    static bool enable_graph_optimization = [] {
-        const char * env     = getenv("GGML_CUDA_GRAPH_OPT");
-        return env != nullptr && atoi(env) == 1;
+    static bool enable_graph_optimization = [cuda_ctx] {
+        const char * env = getenv("GGML_CUDA_GRAPH_OPT");
+        if (env != nullptr) {
+            return atoi(env) == 1;
+        }
+        const int cc = ggml_cuda_info().devices[cuda_ctx->device].cc;
+        return GGML_CUDA_CC_IS_RDNA3_5(cc);
     }();
 
     if (!enable_graph_optimization) {


### PR DESCRIPTION
## Summary
- The CUDA/HIP graph optimization pass (`ggml_backend_cuda_graph_optimize`) was previously opt-in, requiring `GGML_CUDA_GRAPH_OPT=1`.
- Default it to enabled on RDNA3.5 (`GGML_CUDA_CC_IS_RDNA3_5`) while keeping the env var as an explicit override: `GGML_CUDA_GRAPH_OPT=0` disables it, `=1` forces it on.
- All other architectures keep the previous behavior (off unless the env var is set to 1).
- The compute capability is only queried when the env var is unset, so the override path avoids the extra lookup.

## Benchmarks

gfx1151 (RDNA3.5), `llama-bench -ngl 999 -r 40`; VLM via `llama-mtmd-cli` (decode, 128 tokens). OFF = `GGML_CUDA_GRAPH_OPT=0`, ON = `GGML_CUDA_GRAPH_OPT=1` (new default).

Models:
- unsloth/Qwen3.5-0.8B-GGUF (Q4_K_M)
- unsloth/Qwen3.6-35B-A3B-GGUF (UD-Q4_K_M)
- unsloth/Qwen3.6-35B-A3B-GGUF (UD-Q4_K_M + mmproj-BF16, vision)

| model | test | OFF t/s | ON t/s | delta |
| --- | --- | ---: | ---: | ---: |
| Qwen3.5-0.8B | pp128 | 7744 | 7734 | -0.1% |
| Qwen3.5-0.8B | pp2024 | 9215 | 9192 | -0.2% |
| Qwen3.5-0.8B | tg128 | 210.2 | 211.1 | +0.4% |
| Qwen3.6-35B-A3B | pp128 | 1085 | 1093 | +0.7% |
| Qwen3.6-35B-A3B | pp2024 | 1540 | 1555 | +1.0% |
| Qwen3.6-35B-A3B | tg128 | 54.9 | 58.9 | +7.3% |
| Qwen3.6-35B-A3B (VLM) | decode128 | 56.6 | 61.5 | +8.7% |