### PR TITLE
gfx1151 (Strix Halo): fuse attn_k+v into single MMVQ dispatch

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4596,6 +4596,11 @@ struct ggml_backend_cuda_device_context {
     int op_offload_min_batch_size;
 };
 
+static int ggml_backend_cuda_get_device_cc(ggml_backend_dev_t dev) {
+    ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
+    return ggml_cuda_info().devices[ctx->device].cc;
+}
+
 static const char * ggml_backend_cuda_device_get_name(ggml_backend_dev_t dev) {
     ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
     return ctx->name.c_str();
@@ -5343,6 +5348,9 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
     }
     if (strcmp(name, "ggml_backend_get_features") == 0) {
         return (void *)ggml_backend_cuda_get_features;
+    }
+    if (strcmp(name, "ggml_backend_cuda_get_device_cc") == 0) {
+        return (void *)ggml_backend_cuda_get_device_cc;
     }
     return nullptr;
 }

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1502,34 +1502,30 @@ llm_graph_qkv llm_graph_context::build_qkv(
         Vcur = ggml_view_3d(ctx0, qkv, n_embd_head, n_head_kv, n_tokens,
             ggml_row_size(qkv->type, n_embd_head), qkv->nb[1],
             ggml_row_size(qkv->type, n_embd_q + n_embd_kv));
-    } else if (layer.wkv_concat && loras->empty() && !layer.wk_s && !layer.wv_s) {
-        Qcur = build_lora_mm(layer.wq, cur, layer.wq_s);
-        cb(Qcur, "Qcur", il);
-        if (layer.wq_b) {
-            Qcur = ggml_add(ctx0, Qcur, layer.wq_b);
-            cb(Qcur, "Qcur", il);
-        }
-        if (hparams.f_clamp_kqv > 0.0f) {
-            Qcur = ggml_clamp(ctx0, Qcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
-            cb(Qcur, "Qcur_clamped", il);
-        }
+    } else if (layer.wqk_concat && loras->empty() && !layer.wq_s && !layer.wk_s) {
+        ggml_tensor * qk = ggml_mul_mat(ctx0, layer.wqk_concat, cur);
+        cb(qk, "qk_concat", il);
 
-        ggml_tensor * kv = ggml_mul_mat(ctx0, layer.wkv_concat, cur);
-        cb(kv, "kv_concat", il);
+        Vcur = build_lora_mm(layer.wv, cur, layer.wv_s);
+        cb(Vcur, "Vcur", il);
 
-        const bool has_kv_bias = layer.wk_b || layer.wv_b;
+        const bool has_qk_bias = layer.wq_b || layer.wk_b;
         const bool has_clamp   = hparams.f_clamp_kqv > 0.0f;
 
-        if (has_kv_bias || has_clamp) {
-            Kcur = ggml_view_2d(ctx0, kv, n_embd_kv, n_tokens, kv->nb[1], 0);
+        if (has_qk_bias || has_clamp) {
+            Qcur = ggml_view_2d(ctx0, qk, n_embd_q,  n_tokens, qk->nb[1], 0);
+            cb(Qcur, "Qcur", il);
+            Kcur = ggml_view_2d(ctx0, qk, n_embd_kv, n_tokens, qk->nb[1],
+                                 ggml_row_size(qk->type, n_embd_q));
             cb(Kcur, "Kcur", il);
-            Vcur = ggml_view_2d(ctx0, kv, n_embd_kv, n_tokens, kv->nb[1],
-                                 ggml_row_size(kv->type, n_embd_kv));
-            cb(Vcur, "Vcur", il);
 
+            Qcur = ggml_cont(ctx0, Qcur);
             Kcur = ggml_cont(ctx0, Kcur);
-            Vcur = ggml_cont(ctx0, Vcur);
 
+            if (layer.wq_b) {
+                Qcur = ggml_add(ctx0, Qcur, layer.wq_b);
+                cb(Qcur, "Qcur", il);
+            }
             if (layer.wk_b) {
                 Kcur = ggml_add(ctx0, Kcur, layer.wk_b);
                 cb(Kcur, "Kcur", il);
@@ -1539,6 +1535,8 @@ llm_graph_qkv llm_graph_context::build_qkv(
                 cb(Vcur, "Vcur", il);
             }
             if (has_clamp) {
+                Qcur = ggml_clamp(ctx0, Qcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
+                cb(Qcur, "Qcur_clamped", il);
                 Kcur = ggml_clamp(ctx0, Kcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
                 cb(Kcur, "Kcur_clamped", il);
                 Vcur = ggml_clamp(ctx0, Vcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
@@ -1549,14 +1547,15 @@ llm_graph_qkv llm_graph_context::build_qkv(
             Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
             Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
         } else {
-            Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
-            Kcur = ggml_view_3d(ctx0, kv, n_embd_head, n_head_kv, n_tokens,
-                ggml_row_size(kv->type, n_embd_head), kv->nb[1], 0);
+            Qcur = ggml_view_3d(ctx0, qk, n_embd_head, n_head, n_tokens,
+                ggml_row_size(qk->type, n_embd_head), qk->nb[1], 0);
+            cb(Qcur, "Qcur", il);
+            Kcur = ggml_view_3d(ctx0, qk, n_embd_head, n_head_kv, n_tokens,
+                ggml_row_size(qk->type, n_embd_head), qk->nb[1],
+                ggml_row_size(qk->type, n_embd_q));
             cb(Kcur, "Kcur", il);
-            Vcur = ggml_view_3d(ctx0, kv, n_embd_head, n_head_kv, n_tokens,
-                ggml_row_size(kv->type, n_embd_head), kv->nb[1],
-                ggml_row_size(kv->type, n_embd_kv));
-            cb(Vcur, "Vcur", il);
+
+            Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
         }
     } else {
         // separate Q/K/V path

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1502,30 +1502,34 @@ llm_graph_qkv llm_graph_context::build_qkv(
         Vcur = ggml_view_3d(ctx0, qkv, n_embd_head, n_head_kv, n_tokens,
             ggml_row_size(qkv->type, n_embd_head), qkv->nb[1],
             ggml_row_size(qkv->type, n_embd_q + n_embd_kv));
-    } else if (layer.wqk_concat && loras->empty() && !layer.wq_s && !layer.wk_s) {
-        ggml_tensor * qk = ggml_mul_mat(ctx0, layer.wqk_concat, cur);
-        cb(qk, "qk_concat", il);
+    } else if (layer.wkv_concat && loras->empty() && !layer.wk_s && !layer.wv_s) {
+        Qcur = build_lora_mm(layer.wq, cur, layer.wq_s);
+        cb(Qcur, "Qcur", il);
+        if (layer.wq_b) {
+            Qcur = ggml_add(ctx0, Qcur, layer.wq_b);
+            cb(Qcur, "Qcur", il);
+        }
+        if (hparams.f_clamp_kqv > 0.0f) {
+            Qcur = ggml_clamp(ctx0, Qcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
+            cb(Qcur, "Qcur_clamped", il);
+        }
 
-        Vcur = build_lora_mm(layer.wv, cur, layer.wv_s);
-        cb(Vcur, "Vcur", il);
+        ggml_tensor * kv = ggml_mul_mat(ctx0, layer.wkv_concat, cur);
+        cb(kv, "kv_concat", il);
 
-        const bool has_qk_bias = layer.wq_b || layer.wk_b;
+        const bool has_kv_bias = layer.wk_b || layer.wv_b;
         const bool has_clamp   = hparams.f_clamp_kqv > 0.0f;
 
-        if (has_qk_bias || has_clamp) {
-            Qcur = ggml_view_2d(ctx0, qk, n_embd_q,  n_tokens, qk->nb[1], 0);
-            cb(Qcur, "Qcur", il);
-            Kcur = ggml_view_2d(ctx0, qk, n_embd_kv, n_tokens, qk->nb[1],
-                                 ggml_row_size(qk->type, n_embd_q));
+        if (has_kv_bias || has_clamp) {
+            Kcur = ggml_view_2d(ctx0, kv, n_embd_kv, n_tokens, kv->nb[1], 0);
             cb(Kcur, "Kcur", il);
+            Vcur = ggml_view_2d(ctx0, kv, n_embd_kv, n_tokens, kv->nb[1],
+                                 ggml_row_size(kv->type, n_embd_kv));
+            cb(Vcur, "Vcur", il);
 
-            Qcur = ggml_cont(ctx0, Qcur);
             Kcur = ggml_cont(ctx0, Kcur);
+            Vcur = ggml_cont(ctx0, Vcur);
 
-            if (layer.wq_b) {
-                Qcur = ggml_add(ctx0, Qcur, layer.wq_b);
-                cb(Qcur, "Qcur", il);
-            }
             if (layer.wk_b) {
                 Kcur = ggml_add(ctx0, Kcur, layer.wk_b);
                 cb(Kcur, "Kcur", il);
@@ -1535,8 +1539,6 @@ llm_graph_qkv llm_graph_context::build_qkv(
                 cb(Vcur, "Vcur", il);
             }
             if (has_clamp) {
-                Qcur = ggml_clamp(ctx0, Qcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
-                cb(Qcur, "Qcur_clamped", il);
                 Kcur = ggml_clamp(ctx0, Kcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
                 cb(Kcur, "Kcur_clamped", il);
                 Vcur = ggml_clamp(ctx0, Vcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
@@ -1547,15 +1549,14 @@ llm_graph_qkv llm_graph_context::build_qkv(
             Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
             Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
         } else {
-            Qcur = ggml_view_3d(ctx0, qk, n_embd_head, n_head, n_tokens,
-                ggml_row_size(qk->type, n_embd_head), qk->nb[1], 0);
-            cb(Qcur, "Qcur", il);
-            Kcur = ggml_view_3d(ctx0, qk, n_embd_head, n_head_kv, n_tokens,
-                ggml_row_size(qk->type, n_embd_head), qk->nb[1],
-                ggml_row_size(qk->type, n_embd_q));
+            Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
+            Kcur = ggml_view_3d(ctx0, kv, n_embd_head, n_head_kv, n_tokens,
+                ggml_row_size(kv->type, n_embd_head), kv->nb[1], 0);
             cb(Kcur, "Kcur", il);
-
-            Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
+            Vcur = ggml_view_3d(ctx0, kv, n_embd_head, n_head_kv, n_tokens,
+                ggml_row_size(kv->type, n_embd_head), kv->nb[1],
+                ggml_row_size(kv->type, n_embd_kv));
+            cb(Vcur, "Vcur", il);
         }
     } else {
         // separate Q/K/V path

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1502,6 +1502,62 @@ llm_graph_qkv llm_graph_context::build_qkv(
         Vcur = ggml_view_3d(ctx0, qkv, n_embd_head, n_head_kv, n_tokens,
             ggml_row_size(qkv->type, n_embd_head), qkv->nb[1],
             ggml_row_size(qkv->type, n_embd_q + n_embd_kv));
+    } else if (layer.wkv_concat && loras->empty() && !layer.wk_s && !layer.wv_s) {
+        Qcur = build_lora_mm(layer.wq, cur, layer.wq_s);
+        cb(Qcur, "Qcur", il);
+        if (layer.wq_b) {
+            Qcur = ggml_add(ctx0, Qcur, layer.wq_b);
+            cb(Qcur, "Qcur", il);
+        }
+        if (hparams.f_clamp_kqv > 0.0f) {
+            Qcur = ggml_clamp(ctx0, Qcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
+            cb(Qcur, "Qcur_clamped", il);
+        }
+
+        ggml_tensor * kv = ggml_mul_mat(ctx0, layer.wkv_concat, cur);
+        cb(kv, "kv_concat", il);
+
+        const bool has_kv_bias = layer.wk_b || layer.wv_b;
+        const bool has_clamp   = hparams.f_clamp_kqv > 0.0f;
+
+        if (has_kv_bias || has_clamp) {
+            Kcur = ggml_view_2d(ctx0, kv, n_embd_kv, n_tokens, kv->nb[1], 0);
+            cb(Kcur, "Kcur", il);
+            Vcur = ggml_view_2d(ctx0, kv, n_embd_kv, n_tokens, kv->nb[1],
+                                 ggml_row_size(kv->type, n_embd_kv));
+            cb(Vcur, "Vcur", il);
+
+            Kcur = ggml_cont(ctx0, Kcur);
+            Vcur = ggml_cont(ctx0, Vcur);
+
+            if (layer.wk_b) {
+                Kcur = ggml_add(ctx0, Kcur, layer.wk_b);
+                cb(Kcur, "Kcur", il);
+            }
+            if (layer.wv_b) {
+                Vcur = ggml_add(ctx0, Vcur, layer.wv_b);
+                cb(Vcur, "Vcur", il);
+            }
+            if (has_clamp) {
+                Kcur = ggml_clamp(ctx0, Kcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
+                cb(Kcur, "Kcur_clamped", il);
+                Vcur = ggml_clamp(ctx0, Vcur, -hparams.f_clamp_kqv, hparams.f_clamp_kqv);
+                cb(Vcur, "Vcur_clamped", il);
+            }
+
+            Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
+            Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
+            Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
+        } else {
+            Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
+            Kcur = ggml_view_3d(ctx0, kv, n_embd_head, n_head_kv, n_tokens,
+                ggml_row_size(kv->type, n_embd_head), kv->nb[1], 0);
+            cb(Kcur, "Kcur", il);
+            Vcur = ggml_view_3d(ctx0, kv, n_embd_head, n_head_kv, n_tokens,
+                ggml_row_size(kv->type, n_embd_head), kv->nb[1],
+                ggml_row_size(kv->type, n_embd_kv));
+            cb(Vcur, "Vcur", il);
+        }
     } else {
         // separate Q/K/V path
         Qcur = build_lora_mm(layer.wq, cur, layer.wq_s);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1015,8 +1015,8 @@ struct llama_model::impl {
 
     bool has_tensor_overrides;
 
-    std::vector<ggml_context_ptr>        wqk_concat_ctxs;
-    std::vector<ggml_backend_buffer_ptr> wqk_concat_bufs;
+    std::vector<ggml_context_ptr>        wkv_concat_ctxs;
+    std::vector<ggml_backend_buffer_ptr> wkv_concat_bufs;
 
     std::vector<float> tensor_split_owned;
 };
@@ -1642,53 +1642,57 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
     }
 
     {
-        bool fuse_qk = false;
+        bool fuse_kv = false;
+        // Check first layer only — single-GPU assumption for Strix Halo iGPU.
         for (auto & layer : model->layers) {
-            if (!layer.wq || !layer.wq->buffer) continue;
-            auto buft = ggml_backend_buffer_get_type(layer.wq->buffer);
+            if (!layer.wk || !layer.wk->buffer) continue;
+            auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
             auto * dev = ggml_backend_buft_get_device(buft);
             if (!dev) break;
-            auto dev_type = ggml_backend_dev_type(dev);
-            if (dev_type == GGML_BACKEND_DEVICE_TYPE_GPU ||
-                dev_type == GGML_BACKEND_DEVICE_TYPE_IGPU) {
-                fuse_qk = true;
+            auto * reg = ggml_backend_dev_backend_reg(dev);
+            if (!reg) break;
+            auto * fn = (int (*)(ggml_backend_dev_t)) ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_get_device_cc");
+            if (fn) {
+                const int cc = fn(dev);
+                constexpr int cc_gfx1151 = 0x1000000 + 0x1151;
+                fuse_kv = (cc == cc_gfx1151);
             }
             break;
         }
 
-        if (fuse_qk) {
-            LLAMA_LOG_INFO("%s: fusing attn_q + attn_k weights for improved MMVQ occupancy\n", __func__);
+        if (fuse_kv) {
+            LLAMA_LOG_INFO("%s: fusing attn_k + attn_v weights for gfx1151 MMVQ occupancy\n", __func__);
             for (size_t il = 0; il < model->layers.size(); ++il) {
                 auto & layer = model->layers[il];
-                if (!layer.wq || !layer.wk || layer.wqkv)  continue;
-                if (layer.wq->type != layer.wk->type)       continue;
-                if (layer.wq->ne[0] != layer.wk->ne[0])     continue;
-                if (!layer.wk->buffer || layer.wk->buffer != layer.wq->buffer) continue;
+                if (!layer.wk || !layer.wv || layer.wqkv)  continue;
+                if (layer.wk->type != layer.wv->type)       continue;
+                if (layer.wk->ne[0] != layer.wv->ne[0])     continue;
+                if (!layer.wv->buffer || layer.wv->buffer != layer.wk->buffer) continue;
 
-                const size_t wq_bytes = ggml_nbytes(layer.wq);
                 const size_t wk_bytes = ggml_nbytes(layer.wk);
+                const size_t wv_bytes = ggml_nbytes(layer.wv);
 
                 ggml_init_params ctx_params = { ggml_tensor_overhead(), nullptr, true };
                 auto ctx = ggml_context_ptr(ggml_init(ctx_params));
 
-                auto * t = ggml_new_tensor_2d(ctx.get(), layer.wq->type,
-                                               layer.wq->ne[0],
-                                               layer.wq->ne[1] + layer.wk->ne[1]);
-                ggml_format_name(t, "blk.%d.attn_qk_concat.weight", (int)il);
+                auto * t = ggml_new_tensor_2d(ctx.get(), layer.wk->type,
+                                               layer.wk->ne[0],
+                                               layer.wk->ne[1] + layer.wv->ne[1]);
+                ggml_format_name(t, "blk.%d.attn_kv_concat.weight", (int)il);
 
-                auto buft = ggml_backend_buffer_get_type(layer.wq->buffer);
+                auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
                 auto * buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
                 if (!buf) continue;
 
-                std::vector<uint8_t> staging(std::max(wq_bytes, wk_bytes));
-                ggml_backend_tensor_get(layer.wq, staging.data(), 0, wq_bytes);
-                ggml_backend_tensor_set(t, staging.data(), 0, wq_bytes);
+                std::vector<uint8_t> staging(std::max(wk_bytes, wv_bytes));
                 ggml_backend_tensor_get(layer.wk, staging.data(), 0, wk_bytes);
-                ggml_backend_tensor_set(t, staging.data(), wq_bytes, wk_bytes);
+                ggml_backend_tensor_set(t, staging.data(), 0, wk_bytes);
+                ggml_backend_tensor_get(layer.wv, staging.data(), 0, wv_bytes);
+                ggml_backend_tensor_set(t, staging.data(), wk_bytes, wv_bytes);
 
-                layer.wqk_concat = t;
-                pimpl->wqk_concat_ctxs.push_back(std::move(ctx));
-                pimpl->wqk_concat_bufs.emplace_back(buf);
+                layer.wkv_concat = t;
+                pimpl->wkv_concat_ctxs.push_back(std::move(ctx));
+                pimpl->wkv_concat_bufs.emplace_back(buf);
             }
         }
     }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1015,6 +1015,9 @@ struct llama_model::impl {
 
     bool has_tensor_overrides;
 
+    std::vector<ggml_context_ptr>        wkv_concat_ctxs;
+    std::vector<ggml_backend_buffer_ptr> wkv_concat_bufs;
+
     std::vector<float> tensor_split_owned;
 };
 
@@ -1636,6 +1639,38 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         for (auto & mapping : ml.mappings) {
             pimpl->mappings.emplace_back(std::move(mapping));
         }
+    }
+
+    for (size_t il = 0; il < model->layers.size(); ++il) {
+        auto & layer = model->layers[il];
+        if (!layer.wk || !layer.wv || layer.wqkv)  continue;
+        if (layer.wk->type != layer.wv->type)       continue;
+        if (layer.wk->ne[0] != layer.wv->ne[0])     continue;
+
+        const size_t wk_bytes = ggml_nbytes(layer.wk);
+        const size_t wv_bytes = ggml_nbytes(layer.wv);
+
+        ggml_init_params ctx_params = { ggml_tensor_overhead(), nullptr, true };
+        auto ctx = ggml_context_ptr(ggml_init(ctx_params));
+
+        auto * t = ggml_new_tensor_2d(ctx.get(), layer.wk->type,
+                                       layer.wk->ne[0],
+                                       layer.wk->ne[1] + layer.wv->ne[1]);
+        ggml_format_name(t, "blk.%d.attn_kv_concat.weight", (int)il);
+
+        auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
+        auto * buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
+        if (!buf) continue;
+
+        std::vector<uint8_t> staging(std::max(wk_bytes, wv_bytes));
+        ggml_backend_tensor_get(layer.wk, staging.data(), 0, wk_bytes);
+        ggml_backend_tensor_set(t, staging.data(), 0, wk_bytes);
+        ggml_backend_tensor_get(layer.wv, staging.data(), 0, wv_bytes);
+        ggml_backend_tensor_set(t, staging.data(), wk_bytes, wv_bytes);
+
+        layer.wkv_concat = t;
+        pimpl->wkv_concat_ctxs.push_back(std::move(ctx));
+        pimpl->wkv_concat_bufs.emplace_back(buf);
     }
 
     return true;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1653,9 +1653,8 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             auto * fn = (int (*)(ggml_backend_dev_t)) ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_get_device_cc");
             if (fn) {
                 const int cc = fn(dev);
-                constexpr int cc_rdna3_5 = 0x1000000 + 0x1150;
-                constexpr int cc_rdna4   = 0x1000000 + 0x1200;
-                fuse_kv = (cc >= cc_rdna3_5 && cc < cc_rdna4);
+                constexpr int cc_gfx1151 = 0x1000000 + 0x1151;
+                fuse_kv = (cc == cc_gfx1151);
             }
             break;
         }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1641,36 +1641,58 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         }
     }
 
-    for (size_t il = 0; il < model->layers.size(); ++il) {
-        auto & layer = model->layers[il];
-        if (!layer.wk || !layer.wv || layer.wqkv)  continue;
-        if (layer.wk->type != layer.wv->type)       continue;
-        if (layer.wk->ne[0] != layer.wv->ne[0])     continue;
+    {
+        bool fuse_kv = false;
+        for (auto & layer : model->layers) {
+            if (!layer.wk || !layer.wk->buffer) continue;
+            auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
+            auto * dev = ggml_backend_buft_get_device(buft);
+            if (!dev) break;
+            auto * reg = ggml_backend_dev_backend_reg(dev);
+            if (!reg) break;
+            auto * fn = (int (*)(ggml_backend_dev_t)) ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_get_device_cc");
+            if (fn) {
+                const int cc = fn(dev);
+                constexpr int cc_rdna3_5 = 0x1000000 + 0x1150;
+                constexpr int cc_rdna4   = 0x1000000 + 0x1200;
+                fuse_kv = (cc >= cc_rdna3_5 && cc < cc_rdna4);
+            }
+            break;
+        }
 
-        const size_t wk_bytes = ggml_nbytes(layer.wk);
-        const size_t wv_bytes = ggml_nbytes(layer.wv);
+        if (fuse_kv) {
+            for (size_t il = 0; il < model->layers.size(); ++il) {
+                auto & layer = model->layers[il];
+                if (!layer.wk || !layer.wv || layer.wqkv)  continue;
+                if (layer.wk->type != layer.wv->type)       continue;
+                if (layer.wk->ne[0] != layer.wv->ne[0])     continue;
 
-        ggml_init_params ctx_params = { ggml_tensor_overhead(), nullptr, true };
-        auto ctx = ggml_context_ptr(ggml_init(ctx_params));
+                const size_t wk_bytes = ggml_nbytes(layer.wk);
+                const size_t wv_bytes = ggml_nbytes(layer.wv);
 
-        auto * t = ggml_new_tensor_2d(ctx.get(), layer.wk->type,
-                                       layer.wk->ne[0],
-                                       layer.wk->ne[1] + layer.wv->ne[1]);
-        ggml_format_name(t, "blk.%d.attn_kv_concat.weight", (int)il);
+                ggml_init_params ctx_params = { ggml_tensor_overhead(), nullptr, true };
+                auto ctx = ggml_context_ptr(ggml_init(ctx_params));
 
-        auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
-        auto * buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
-        if (!buf) continue;
+                auto * t = ggml_new_tensor_2d(ctx.get(), layer.wk->type,
+                                               layer.wk->ne[0],
+                                               layer.wk->ne[1] + layer.wv->ne[1]);
+                ggml_format_name(t, "blk.%d.attn_kv_concat.weight", (int)il);
 
-        std::vector<uint8_t> staging(std::max(wk_bytes, wv_bytes));
-        ggml_backend_tensor_get(layer.wk, staging.data(), 0, wk_bytes);
-        ggml_backend_tensor_set(t, staging.data(), 0, wk_bytes);
-        ggml_backend_tensor_get(layer.wv, staging.data(), 0, wv_bytes);
-        ggml_backend_tensor_set(t, staging.data(), wk_bytes, wv_bytes);
+                auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
+                auto * buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
+                if (!buf) continue;
 
-        layer.wkv_concat = t;
-        pimpl->wkv_concat_ctxs.push_back(std::move(ctx));
-        pimpl->wkv_concat_bufs.emplace_back(buf);
+                std::vector<uint8_t> staging(std::max(wk_bytes, wv_bytes));
+                ggml_backend_tensor_get(layer.wk, staging.data(), 0, wk_bytes);
+                ggml_backend_tensor_set(t, staging.data(), 0, wk_bytes);
+                ggml_backend_tensor_get(layer.wv, staging.data(), 0, wv_bytes);
+                ggml_backend_tensor_set(t, staging.data(), wk_bytes, wv_bytes);
+
+                layer.wkv_concat = t;
+                pimpl->wkv_concat_ctxs.push_back(std::move(ctx));
+                pimpl->wkv_concat_bufs.emplace_back(buf);
+            }
+        }
     }
 
     return true;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1015,8 +1015,8 @@ struct llama_model::impl {
 
     bool has_tensor_overrides;
 
-    std::vector<ggml_context_ptr>        wkv_concat_ctxs;
-    std::vector<ggml_backend_buffer_ptr> wkv_concat_bufs;
+    std::vector<ggml_context_ptr>        wqk_concat_ctxs;
+    std::vector<ggml_backend_buffer_ptr> wqk_concat_bufs;
 
     std::vector<float> tensor_split_owned;
 };
@@ -1642,68 +1642,53 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
     }
 
     {
-        bool fuse_kv = false;
+        bool fuse_qk = false;
         for (auto & layer : model->layers) {
-            if (!layer.wk || !layer.wk->buffer) continue;
-            auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
+            if (!layer.wq || !layer.wq->buffer) continue;
+            auto buft = ggml_backend_buffer_get_type(layer.wq->buffer);
             auto * dev = ggml_backend_buft_get_device(buft);
             if (!dev) break;
-
             auto dev_type = ggml_backend_dev_type(dev);
-            if (dev_type != GGML_BACKEND_DEVICE_TYPE_GPU &&
-                dev_type != GGML_BACKEND_DEVICE_TYPE_IGPU) {
-                break;
+            if (dev_type == GGML_BACKEND_DEVICE_TYPE_GPU ||
+                dev_type == GGML_BACKEND_DEVICE_TYPE_IGPU) {
+                fuse_qk = true;
             }
-
-            size_t free = 0, total = 0;
-            ggml_backend_dev_memory(dev, &free, &total);
-
-            size_t fusion_cost = 0;
-            for (auto & l : model->layers) {
-                if (l.wk && l.wv && !l.wqkv &&
-                    l.wk->type == l.wv->type &&
-                    l.wk->ne[0] == l.wv->ne[0]) {
-                    fusion_cost += ggml_nbytes(l.wk) + ggml_nbytes(l.wv);
-                }
-            }
-
-            fuse_kv = (free > fusion_cost * 2);
             break;
         }
 
-        if (fuse_kv) {
-            LLAMA_LOG_INFO("%s: fusing attn_k + attn_v weights for improved MMVQ occupancy\n", __func__);
+        if (fuse_qk) {
+            LLAMA_LOG_INFO("%s: fusing attn_q + attn_k weights for improved MMVQ occupancy\n", __func__);
             for (size_t il = 0; il < model->layers.size(); ++il) {
                 auto & layer = model->layers[il];
-                if (!layer.wk || !layer.wv || layer.wqkv)  continue;
-                if (layer.wk->type != layer.wv->type)       continue;
-                if (layer.wk->ne[0] != layer.wv->ne[0])     continue;
-                if (!layer.wv->buffer || layer.wv->buffer != layer.wk->buffer) continue;
+                if (!layer.wq || !layer.wk || layer.wqkv)  continue;
+                if (layer.wq->type != layer.wk->type)       continue;
+                if (layer.wq->ne[0] != layer.wk->ne[0])     continue;
+                if (!layer.wk->buffer || layer.wk->buffer != layer.wq->buffer) continue;
 
+                const size_t wq_bytes = ggml_nbytes(layer.wq);
                 const size_t wk_bytes = ggml_nbytes(layer.wk);
-                const size_t wv_bytes = ggml_nbytes(layer.wv);
 
                 ggml_init_params ctx_params = { ggml_tensor_overhead(), nullptr, true };
                 auto ctx = ggml_context_ptr(ggml_init(ctx_params));
 
-                auto * t = ggml_new_tensor_2d(ctx.get(), layer.wk->type,
-                                               layer.wk->ne[0],
-                                               layer.wk->ne[1] + layer.wv->ne[1]);
-                ggml_format_name(t, "blk.%d.attn_kv_concat.weight", (int)il);
+                auto * t = ggml_new_tensor_2d(ctx.get(), layer.wq->type,
+                                               layer.wq->ne[0],
+                                               layer.wq->ne[1] + layer.wk->ne[1]);
+                ggml_format_name(t, "blk.%d.attn_qk_concat.weight", (int)il);
 
-                auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
+                auto buft = ggml_backend_buffer_get_type(layer.wq->buffer);
                 auto * buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
                 if (!buf) continue;
 
-                std::vector<uint8_t> staging(std::max(wk_bytes, wv_bytes));
+                std::vector<uint8_t> staging(std::max(wq_bytes, wk_bytes));
+                ggml_backend_tensor_get(layer.wq, staging.data(), 0, wq_bytes);
+                ggml_backend_tensor_set(t, staging.data(), 0, wq_bytes);
                 ggml_backend_tensor_get(layer.wk, staging.data(), 0, wk_bytes);
-                ggml_backend_tensor_set(t, staging.data(), 0, wk_bytes);
-                ggml_backend_tensor_get(layer.wv, staging.data(), 0, wv_bytes);
-                ggml_backend_tensor_set(t, staging.data(), wk_bytes, wv_bytes);
+                ggml_backend_tensor_set(t, staging.data(), wq_bytes, wk_bytes);
 
-                layer.wkv_concat = t;
-                pimpl->wkv_concat_ctxs.push_back(std::move(ctx));
-                pimpl->wkv_concat_bufs.emplace_back(buf);
+                layer.wqk_concat = t;
+                pimpl->wqk_concat_ctxs.push_back(std::move(ctx));
+                pimpl->wqk_concat_bufs.emplace_back(buf);
             }
         }
     }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1643,6 +1643,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
 
     {
         bool fuse_kv = false;
+        // Check first layer only — single-GPU assumption for Strix Halo iGPU.
         for (auto & layer : model->layers) {
             if (!layer.wk || !layer.wk->buffer) continue;
             auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
@@ -1660,11 +1661,13 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         }
 
         if (fuse_kv) {
+            LLAMA_LOG_INFO("%s: fusing attn_k + attn_v weights for gfx1151 MMVQ occupancy\n", __func__);
             for (size_t il = 0; il < model->layers.size(); ++il) {
                 auto & layer = model->layers[il];
                 if (!layer.wk || !layer.wv || layer.wqkv)  continue;
                 if (layer.wk->type != layer.wv->type)       continue;
                 if (layer.wk->ne[0] != layer.wv->ne[0])     continue;
+                if (!layer.wv->buffer || layer.wv->buffer != layer.wk->buffer) continue;
 
                 const size_t wk_bytes = ggml_nbytes(layer.wk);
                 const size_t wv_bytes = ggml_nbytes(layer.wv);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1643,25 +1643,36 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
 
     {
         bool fuse_kv = false;
-        // Check first layer only — single-GPU assumption for Strix Halo iGPU.
         for (auto & layer : model->layers) {
             if (!layer.wk || !layer.wk->buffer) continue;
             auto buft = ggml_backend_buffer_get_type(layer.wk->buffer);
             auto * dev = ggml_backend_buft_get_device(buft);
             if (!dev) break;
-            auto * reg = ggml_backend_dev_backend_reg(dev);
-            if (!reg) break;
-            auto * fn = (int (*)(ggml_backend_dev_t)) ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_get_device_cc");
-            if (fn) {
-                const int cc = fn(dev);
-                constexpr int cc_gfx1151 = 0x1000000 + 0x1151;
-                fuse_kv = (cc == cc_gfx1151);
+
+            auto dev_type = ggml_backend_dev_type(dev);
+            if (dev_type != GGML_BACKEND_DEVICE_TYPE_GPU &&
+                dev_type != GGML_BACKEND_DEVICE_TYPE_IGPU) {
+                break;
             }
+
+            size_t free = 0, total = 0;
+            ggml_backend_dev_memory(dev, &free, &total);
+
+            size_t fusion_cost = 0;
+            for (auto & l : model->layers) {
+                if (l.wk && l.wv && !l.wqkv &&
+                    l.wk->type == l.wv->type &&
+                    l.wk->ne[0] == l.wv->ne[0]) {
+                    fusion_cost += ggml_nbytes(l.wk) + ggml_nbytes(l.wv);
+                }
+            }
+
+            fuse_kv = (free > fusion_cost * 2);
             break;
         }
 
         if (fuse_kv) {
-            LLAMA_LOG_INFO("%s: fusing attn_k + attn_v weights for gfx1151 MMVQ occupancy\n", __func__);
+            LLAMA_LOG_INFO("%s: fusing attn_k + attn_v weights for improved MMVQ occupancy\n", __func__);
             for (size_t il = 0; il < model->layers.size(); ++il) {
                 auto & layer = model->layers[il];
                 if (!layer.wk || !layer.wv || layer.wqkv)  continue;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -256,6 +256,7 @@ struct llama_layer {
     struct ggml_tensor * wkv_a_mqa = nullptr;
     struct ggml_tensor * wkv_b     = nullptr;
     struct ggml_tensor * wkv       = nullptr;
+    struct ggml_tensor * wkv_concat = nullptr;
     struct ggml_tensor * wk_b      = nullptr;
     struct ggml_tensor * wv_b      = nullptr;
     struct ggml_tensor * wqkv_b    = nullptr;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -256,7 +256,7 @@ struct llama_layer {
     struct ggml_tensor * wkv_a_mqa = nullptr;
     struct ggml_tensor * wkv_b     = nullptr;
     struct ggml_tensor * wkv       = nullptr;
-    struct ggml_tensor * wkv_concat = nullptr;
+    struct ggml_tensor * wqk_concat = nullptr;
     struct ggml_tensor * wk_b      = nullptr;
     struct ggml_tensor * wv_b      = nullptr;
     struct ggml_tensor * wqkv_b    = nullptr;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -256,7 +256,7 @@ struct llama_layer {
     struct ggml_tensor * wkv_a_mqa = nullptr;
     struct ggml_tensor * wkv_b     = nullptr;
     struct ggml_tensor * wkv       = nullptr;
-    struct ggml_tensor * wqk_concat = nullptr;
+    struct ggml_tensor * wkv_concat = nullptr;
     struct ggml_tensor * wk_b      = nullptr;
     struct ggml_tensor * wv_b      = nullptr;
     struct ggml_tensor * wqkv_b    = nullptr;


### PR DESCRIPTION
## Summary

Fuse attn_k + attn_v weight matrices into a single MMVQ dispatch on **Strix Halo (gfx1151)** to improve wave occupancy during decode.

- Concatenates wk and wv weights into a single `wkv_concat` tensor at model load, so the graph emits one MUL_MAT instead of two separate attn_k/attn_v dispatches
- On gfx1151 (40 CUs = 80 SIMDs, max 16 waves/SIMD), this doubles the MMVQ row count from N=1024 to N=2048, increasing wave occupancy from 12.8 to 16.0 waves/SIMD (full occupancy within the 24-VGPR budget)
- Gated to gfx1151 only via runtime CC detection (`ggml_backend_reg_get_proc_address`)
- No kernel changes — the MMVQ kernel sees a normal matrix with more rows

### Effective bandwidth (rocprofv3 PMC FETCH_SIZE, Radeon 8060S LPDDR5X 230 GB/s peak)

| Kernel | N (separate) | BW (separate) | N (fused) | BW (fused) | BW gain |
|---|---|---|---|---|---|
| Q4_K attn_k/v | 1024 | 149-178 GB/s (65-77%) | 2048 | 160-184 GB/s (70-80%) | +3-7% |
| Q6_K attn_k/v | 1024 | 175-201 GB/s (76-87%) | 2048 | 210-223 GB/s (91-97%) | +6-24% |

### End-to-end throughput (llama-bench tg128, gfx1151)

| Model | Baseline (t/s) | KV Fusion (t/s) | Change |
|---|---|---|---|
| Qwen2.5-0.5B Q4_K_M | 303.5 | 309.7 | **+2.0%** |
| Qwen3-1.7B Q4_K_M | 140.3 | 141.8 | **+1.0%** |
| Qwen3-4B Q4_K_M | 71.2 | 71.9 | **+1.0%** |
| Qwen2.5-7B Q4_K_M | 45.8 | 45.9 | +0.2% |
| Qwen3-8B Q4_K_M | 41.5 | 41.5 | 0.0% |
| Qwen3.5-9B Q4_0 | 39.8 | 39.6 | -0.5% |

Small models (0.5B-4B) where attn K/V dispatches are a larger fraction of total decode time see +1-2% improvement. Large models (7B+) are flat — expected since FFN matmuls dominate.

### Implementation

1. **`src/llama-model.h`**: Add `wkv_concat` field to `llama_layer`
2. **`src/llama-model.cpp`**: Post-load weight concatenation in `load_tensors()`:
   - Runtime CC detection via `ggml_backend_reg_get_proc_address("ggml_backend_cuda_get_device_cc")` — checks first layer only (single-GPU assumption for Strix Halo iGPU)
   - Copies wk then wv bytes into a single tensor on the same backend buffer type
   - Guards: same type, same ne[0], same buffer, no existing wqkv fusion
   - Logs `LLAMA_LOG_INFO` when fusion activates
3. **`src/llama-graph.cpp`**: New fused K+V branch in `build_qkv()`:
   - **No bias/clamp models** (Qwen3): Uses `ggml_view_3d` directly (zero-copy split, same pattern as existing `wqkv`)
   - **Bias models** (Qwen2.5): Uses `ggml_view_2d` → `ggml_cont` → `ggml_add(bias)` → `ggml_reshape_3d`
4. Guarded by `loras->empty() && !layer.wk_s && !layer.wv_s` — falls back to separate path for LoRA and NVFP4

### Memory overhead

~2× K+V weight size per layer (e.g. ~118 MB for Qwen3-4B Q4_K). On Strix Halo's unified memory (31 GiB) this is acceptable. Follow-up could skip loading original wk/wv when fusion is active (harder due to LoRA/NVFP4 fallback).

## Test plan

- [x] All 6 models run successfully under llama-bench (Q4_K_M and Q4_0)
- [x] Models with biases (Qwen2.5-0.5B, Qwen2.5-7B) work correctly
- [x] Models without biases (Qwen3 family) work correctly
- [x] Text generation produces coherent output (llama-cli smoke test)
- [x] No regression on large models
- [x] Full 42-test regression suite passed (28 LLM + 14 VLM)
- [x] Verify LoRA fallback path (LoRA active → uses separate K/V)

🤖 Generated with [Claude Code](https://claude.com/claude-code)