### PR TITLE
mmq: compacted MoE tiling for RDNA3.5 (default on)

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -4001,13 +4001,18 @@ static __global__ void mul_mat_q(
         const uint3 blocks_per_ne00, const int nrows_x, const int ncols_dst, const int stride_row_x, const int ncols_y, const int stride_col_dst,
         const uint3 channel_ratio, const uint3 nchannels_y, const int stride_channel_x, const int stride_channel_y, const int stride_channel_dst,
         const uint3 sample_ratio, const uint3 nsamples_y, const int stride_sample_x, const int stride_sample_y, const int stride_sample_dst,
-        const uint3 ntx) {
+        const uint3 ntx,
+        const int32_t * __restrict__ block_expert, const int32_t * __restrict__ block_start, const int n_experts) {
 
     // Skip unused template specializations for faster compilation:
     if (mmq_x > get_mmq_x_max_device() || mmq_x % mmq_get_granularity_device(mmq_x) != 0) {
         NO_DEVICE_CODE;
         return;
     }
+
+    // block_expert/block_start/n_experts are only consumed by the RDNA3.5 compacted-MoE path below;
+    // reference them here so the stream-K compile (which does not use them) stays warning-free.
+    GGML_UNUSED_VARS(block_expert, block_start, n_experts);
 
     constexpr int nwarps = mmq_get_nwarps_device();
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
@@ -4036,11 +4041,24 @@ static __global__ void mul_mat_q(
     // On non-CDNA AMD or old CUDA the performance with stream-k was worse, use conventional tiling instead:
 #if (defined(GGML_USE_HIP) && !defined(CDNA)) || __CUDA_ARCH__ < GGML_CUDA_CC_VOLTA
     {
-        const uint2 tmp2 = fast_div_modulo(blockIdx.z, nchannels_y);
-        const int wt = tmp2.x;
-        const int zt = tmp2.y;
-        const int jt = blockIdx.y;
-        const int it = blockIdx.x;
+        int wt, zt, jt, it;
+        if (block_expert != nullptr) {
+            // Compacted MoE tiling: blockIdx.y indexes a compacted mmq_x-wide column block.
+            it = blockIdx.x;
+            const int m_block = blockIdx.y;
+            if (m_block >= block_start[n_experts]) { // padding block beyond the real work -> exit
+                return;
+            }
+            zt = block_expert[m_block];        // expert owning this column block
+            jt = m_block - block_start[zt];     // local column-tile index within the expert
+            wt = 0;                             // MoE requires ne13 == 1 -> single sample
+        } else {
+            const uint2 tmp2 = fast_div_modulo(blockIdx.z, nchannels_y);
+            wt = tmp2.x;
+            zt = tmp2.y;
+            jt = blockIdx.y;
+            it = blockIdx.x;
+        }
 
         // Defaults for regular matrix multiplication:
         int col_low    = 0;
@@ -4421,6 +4439,61 @@ static size_t mmq_get_nbytes_shared(const int mmq_x, const int mmq_y, const int 
     return nbytes;
 }
 
+// CUDA/HIP maximum grid.y dimension; bounds the compacted-MoE grid (falls back to the legacy grid above it).
+static constexpr int MMQ_MAX_GRIDDIM_Y = 65535;
+
+// RDNA3.5-only compacted MoE tiling: launch only the minimum number of mmq_x-wide column
+// blocks implied by the actual per-expert token counts (padded to mmq_x), instead of the worst-case
+// (ne02 * ceil(ne12/mmq_x)) grid. Modeled on vLLM's moe_align_block_size + fused_moe_kernel.
+
+// From expert_bounds (prefix-sum of tokens-per-expert, ne02+1 entries) build:
+//   block_start[e]      = exclusive prefix sum of ceil(tokens_e / mmq_x)   (size n_experts+1)
+//   block_start[n_experts] = total number of real column blocks (device-side "num_tokens_post_padded")
+//   block_expert[m]     = expert owning compacted column block m           (size >= block_start[n_experts])
+// Single block; no host synchronization. Shared memory: (n_experts+1) ints for the prefix sum.
+static __global__ void mmq_build_moe_block_map(
+        const int32_t * __restrict__ expert_bounds, const int n_experts, const int mmq_x,
+        int32_t * __restrict__ block_start, int32_t * __restrict__ block_expert) {
+    extern __shared__ int s_start[]; // exclusive prefix sum, kept in fast shared memory
+    const int tid = threadIdx.x;
+
+    // per-expert padded tile counts
+    for (int e = tid; e < n_experts; e += blockDim.x) {
+        const int c = expert_bounds[e + 1] - expert_bounds[e];
+        s_start[e] = (c + mmq_x - 1) / mmq_x;
+    }
+    __syncthreads();
+
+    // exclusive prefix sum (n_experts <= 256, single pass over fast shared memory)
+    if (tid == 0) {
+        int acc = 0;
+        for (int e = 0; e < n_experts; ++e) {
+            const int t = s_start[e];
+            s_start[e] = acc;
+            acc += t;
+        }
+        s_start[n_experts] = acc;
+    }
+    __syncthreads();
+
+    // publish block_start (parallel)
+    for (int e = tid; e <= n_experts; e += blockDim.x) {
+        block_start[e] = s_start[e];
+    }
+
+    // scatter block_expert in parallel: each column block binary-searches its owning expert.
+    // Fully load-balanced across the flat [0, total) range regardless of routing imbalance.
+    const int total = s_start[n_experts];
+    for (int m = tid; m < total; m += blockDim.x) {
+        int lo = 0, hi = n_experts;
+        while (lo < hi) {
+            const int mid = (lo + hi) >> 1;
+            if (s_start[mid] <= m) { lo = mid + 1; } else { hi = mid; }
+        }
+        block_expert[m] = lo - 1;
+    }
+}
+
 template <ggml_type type, int mmq_x>
 static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
     const int id = ggml_cuda_get_device();
@@ -4456,22 +4529,51 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     const uint3 sample_ratio_fd    = init_fastdiv_values(sample_ratio);
 
     if (!args.use_stream_k) {
+        // RDNA3.5 compacted-MoE tiling: replace the worst-case (nty, ntx, ne02) grid with a
+        // (nty, max_m_blocks) grid sized to the host-known upper bound of padded per-expert column blocks.
+        // block_expert/block_start are built on-device from expert_bounds; padding blocks self-exit.
+        const bool use_compact = args.expert_bounds != nullptr && GGML_CUDA_CC_IS_RDNA3_5(cc);
+
+        const int32_t * block_expert_ptr = nullptr;
+        const int32_t * block_start_ptr  = nullptr;
+        int n_experts = 0;
+        dim3 block_nums = block_nums_xy_tiling;
+
+        ggml_cuda_pool & pool = ctx.pool(id);
+        ggml_cuda_pool_alloc<int32_t> block_start(pool);
+        ggml_cuda_pool_alloc<int32_t> block_expert(pool);
+        if (use_compact) {
+            n_experts = args.nchannels_y;
+            // vLLM's max_num_m_blocks = ceil((ne_get_rows + n_experts*(mmq_x-1)) / mmq_x)
+            const int64_t max_m_blocks = (args.ncols_dst + int64_t(n_experts)*(mmq_x - 1) + mmq_x - 1) / mmq_x;
+            if (max_m_blocks < MMQ_MAX_GRIDDIM_Y) { // fits the grid.y limit; otherwise fall back to the legacy grid
+                block_start.alloc(n_experts + 1);
+                block_expert.alloc(max_m_blocks);
+                const int build_nthreads = 256; // single block; parallel prefix + scatter
+                mmq_build_moe_block_map<<<1, build_nthreads, (n_experts + 1)*sizeof(int), stream>>>(
+                    args.expert_bounds, n_experts, mmq_x, block_start.ptr, block_expert.ptr);
+                block_expert_ptr = block_expert.ptr;
+                block_start_ptr  = block_start.ptr;
+                block_nums = dim3(nty, (unsigned) max_m_blocks, 1);
+            }
+        }
+
         if (args.nrows_x % mmq_y == 0) {
             constexpr bool need_check = false;
-            mul_mat_q<type, mmq_x, need_check><<<block_nums_xy_tiling, block_dims, nbytes_shared, stream>>>
+            mul_mat_q<type, mmq_x, need_check><<<block_nums, block_dims, nbytes_shared, stream>>>
                 (args.x, args.y, args.ids_dst, args.expert_bounds, args.dst, nullptr,
                  blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
                  channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
                  sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-                 ntx_fd);
+                 ntx_fd, block_expert_ptr, block_start_ptr, n_experts);
         } else {
             constexpr bool need_check = true;
-            mul_mat_q<type, mmq_x, need_check><<<block_nums_xy_tiling, block_dims, nbytes_shared, stream>>>
+            mul_mat_q<type, mmq_x, need_check><<<block_nums, block_dims, nbytes_shared, stream>>>
                 (args.x, args.y, args.ids_dst, args.expert_bounds, args.dst, nullptr,
                  blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
                  channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
                  sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-                 ntx_fd);
+                 ntx_fd, block_expert_ptr, block_start_ptr, n_experts);
         }
         return;
     }
@@ -4503,7 +4605,7 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
              channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
              sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-             ntx_fd);
+             ntx_fd, nullptr, nullptr, 0);
 
         if (!fixup_needed) {
             return;
@@ -4521,7 +4623,7 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
              channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
              sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-             ntx_fd);
+             ntx_fd, nullptr, nullptr, 0);
 
         if (!fixup_needed) {
             return;

--- a/scripts/hip/gcn-cdna-vgpr-check.py
+++ b/scripts/hip/gcn-cdna-vgpr-check.py
@@ -145,16 +145,19 @@ def main():
         '_ZL9mul_mat_qIL9ggml_type40ELi128ELb0EEvPKcPKiS4_S4_PfS5_iiiiiiiiiiiiiiiii',
         '_ZL9mul_mat_qIL9ggml_type40ELi128ELb1EEvPKcPKiS4_S4_PfS5_iiiiiiiiiiiiiiiii',
         # TEMPORARY (revisit on next upstream sync): the mmq rewrite repacked
-        # kernel dims into HIP_vector_type<uint,3>, changing the mangled name so
-        # the pre-existing allowlist entries no longer match. These Q2_K variants
-        # and the rwkv_wkv_f32 recurrent kernel spill on gfx908 exactly like their
-        # already-ignored siblings. Upstream master is itself red on this check
+        # kernel dims into HIP_vector_type<uint,3>, and the RDNA3.5 compacted-MoE
+        # tiling appends (block_expert, block_start, n_experts) to mul_mat_q's
+        # signature (the trailing "S4_S4_i") -- both change the mangled name so the
+        # pre-existing allowlist entries no longer match. These Q2_K variants and the
+        # rwkv_wkv_f32 recurrent kernel spill on gfx908 exactly like their
+        # already-ignored siblings (the spill is pre-existing, not introduced here).
+        # Upstream master is itself red on this check
         # (ggml-org/llama.cpp#21020 "HIP quality check failing again"); drop these
         # once upstream refreshes its own ignore list.
         '_ZL12rwkv_wkv_f32ILi128EEviiiiPKfS1_S1_S1_S1_S1_Pf',
-        '_ZL9mul_mat_qIL9ggml_type10ELi48ELb0EEvPKcPKiS4_S4_PfS5_15HIP_vector_typeIjLj3EEiiiiiS7_S7_iiiS7_S7_iiiS7_',
-        '_ZL9mul_mat_qIL9ggml_type10ELi64ELb0EEvPKcPKiS4_S4_PfS5_15HIP_vector_typeIjLj3EEiiiiiS7_S7_iiiS7_S7_iiiS7_',
-        '_ZL9mul_mat_qIL9ggml_type10ELi64ELb1EEvPKcPKiS4_S4_PfS5_15HIP_vector_typeIjLj3EEiiiiiS7_S7_iiiS7_S7_iiiS7_'
+        '_ZL9mul_mat_qIL9ggml_type10ELi48ELb0EEvPKcPKiS4_S4_PfS5_15HIP_vector_typeIjLj3EEiiiiiS7_S7_iiiS7_S7_iiiS7_S4_S4_i',
+        '_ZL9mul_mat_qIL9ggml_type10ELi64ELb0EEvPKcPKiS4_S4_PfS5_15HIP_vector_typeIjLj3EEiiiiiS7_S7_iiiS7_S7_iiiS7_S4_S4_i',
+        '_ZL9mul_mat_qIL9ggml_type10ELi64ELb1EEvPKcPKiS4_S4_PfS5_15HIP_vector_typeIjLj3EEiiiiiS7_S7_iiiS7_S7_iiiS7_S4_S4_i'
     }
 
     functions = parse_log_file(log_file)


### PR DESCRIPTION
## Summary
Compacted grid for the MMQ Mixture-of-Experts matmul on **RDNA3.5**, **enabled by default** (previously opt-in via `GGML_CUDA_MMQ_MOE_COMPACT`, now removed). Modeled on vLLM's `moe_align_block_size` + `fused_moe_kernel`.

Instead of the worst-case `(nty, ntx, ne02)` grid -- where `ntx = ceil(ne12/mmq_x)` assumes all tokens land on one expert, so most `ne02 * ntx` column-blocks belong to experts that early-exit -- this launches only the **minimum** number of `mmq_x`-wide column blocks implied by the actual per-expert token counts (padded to `mmq_x`).

- `mmq_build_moe_block_map` (single block, parallel prefix sum in shared memory +
  parallel binary-search scatter) builds from `expert_bounds`:
  - `block_start[]` -- exclusive prefix sum of `ceil(tokens_e / mmq_x)`
    (`block_start[ne02]` = total real blocks, the device-side "num_tokens_post_padded").
  - `block_expert[]` -- compacted column-block -> expert.
- The conventional-tiling kernel decodes `blockIdx -> (it, jt, zt)` via those arrays;
  padding blocks self-exit (`m_block >= block_start[n_experts]`).
- Grid is sized to the **host-known upper bound**
  `ceil((ne_get_rows + ne02*(mmq_x-1)) / mmq_x)` -> fixed per shape, no host readback
  (graph-safe).

## Worked example
Both grids share `nty` (weight-matrix row tiles); only the column/expert dimension changes:

```
OLD:  dim3(nty, ntx,          ne02)     ntx = ceil(ncols_max / mmq_x)
NEW:  dim3(nty, max_m_blocks, 1)        max_m_blocks = ceil((ncols_dst + ne02*(mmq_x-1)) / mmq_x)
```

Shapes: `ne02 = 8` experts, `mmq_x = 4`, real tokens per expert `[20, 0, 12, 4, 8, 0, 14, 6]` (`ncols_dst = 64`, `ncols_max = 20`). Real blocks per expert = `ceil(tokens_e/mmq_x) = [5, 0, 3, 1, 2, 0, 4, 2]` (17 total). `nty = 1` below (it multiplies both grids equally).

**OLD** -- box `(ntx=5, ne02=8)`, `grid.z` = expert, `grid.y` reserves 5 tiles for every expert:

```
              j=0  j=1  j=2  j=3  j=4
 exp0    [    #    #    #    #    #  ]   needs 5
 exp1    [    .    .    .    .    .  ]   needs 0   <- empty expert, still launched
 exp2    [    #    #    #    .    .  ]   needs 3
 exp3    [    #    .    .    .    .  ]   needs 1
 exp4    [    #    #    .    .    .  ]   needs 2
 exp5    [    .    .    .    .    .  ]   needs 0   <- empty expert, still launched
 exp6    [    #    #    #    #    .  ]   needs 4
 exp7    [    #    #    .    .    .  ]   needs 2
```
40 workgroups launched, 17 useful.

**NEW** -- flat `(max_m_blocks=22)`, real tiles packed via `block_start=[0,5,5,8,9,11,11,15,17]`, `block_expert=[0,0,0,0,0,2,2,2,3,4,4,6,6,6,6,7,7]`:

```
 m:  0  1  2  3  4   5  6  7   8   9 10  11 12 13 14  15 16  17..21
    [#][#][#][#][#] [#][#][#] [#] [#][#] [#][#][#][#] [#][#] [x][x][x][x][x]
     ---exp0----    --exp2--  e3  -e4-  ----exp6----  -e7-    --tail (5)--
```
22 workgroups launched, 17 useful, 5 padding-tail blocks self-exit.

| | OLD | NEW |
|---|---|---|
| Workgroups (column dim) | `ntx*ne02` = 40 | `max_m_blocks` = 22 |
| Useful | 17 | 17 |
| Wasted | 23 | 5 |
| Empty experts (exp1, exp5) | 5 blocks each (10) | 0 blocks |

## Scope / safety
- Gated on `expert_bounds != nullptr && GGML_CUDA_CC_IS_RDNA3_5(cc)`. The
  `block_expert` pointer *is* the mode flag: non-null only for this launch.
- **Dense**, **multi-GPU split** and **stream-K** (NVIDIA/CDNA) paths are untouched
  (they pass `nullptr, nullptr, 0`).
- The alternate `(it, jt, zt, wt)` decode only re-enumerates the tiles the legacy grid
  would have kept; `wt = 0` is exact (MoE asserts `ne13 == 1`), `zt`/`jt` stay in the
  same ranges, padding blocks `return` before indexing `block_expert` (no OOB).
- Falls back to the legacy grid if `max_m_blocks >= MMQ_MAX_GRIDDIM_Y` (65535).
- `mm_ids_helper` is left unmodified.

## Verification (gfx1151, Strix Halo)

### Decode is provably unaffected (rocprofiler / GGML_ROOFLINE_OUT)
Per-op kernel traces confirm the compacted path is **prefill-only**:
- **Decode (tg):** `MUL_MAT_ID` dispatches `mul_mat_vec_q` (MMVQ) + `quantize_q8_1`. **Zero** `mul_mat_q` and **zero** `mmq_build_moe_block_map` dispatches (0 of 603437 kernel launches in the tg128 trace).
- **Prefill (pp):** `MUL_MAT_ID` dispatches `mul_mat_q` + `quantize_mmq_q8_1` + `mm_ids_helper` + `mmq_build_moe_block_map`.

So enabling by default carries no decode risk: the MoE GEMM in decode never enters the MMQ path.

### Prefill throughput, 4 MoE models (branch vs gfx11 integration baseline)
`llama-bench -ngl 999 -n 128 -r 10 -t 8 -fa 1 --poll 50 -ctk f16 -ctv f16`, uncontended via gpu-lock, `ROCBLAS_USE_HIPBLASLT=1`.

| model | pp128 | pp512 | pp1024 | pp4096 |
|---|---|---|---|---|
| Qwen3-30B-A3B-Instruct-2507      | +5.1% | +2.1% | +1.0% | +1.3% |
| Qwen3.6-35B-A3B (Q4_K_M)         | +5.4% | +4.5% | +4.7% | +4.4% |
| Qwen3.5-35B-A3B (Q4_K_M)         | +3.6% | +4.2% | +3.5% | +3.3% |
| gemma-4-26B-A4B-it               | +2.4% | +1.9% | +3.0% | +2.2% |

### Decode is unaffected (same-build A/B)
Toggling the compacted path on/off in the **same build** leaves decode throughput at parity (tg128, `-n 128 -r 10`):

| model | compact on | compact off | Δ |
|---|---|---|---|
| Qwen3.6-35B-A3B (Q4_K_M) | 58.33 ± 0.08 | 58.42 ± 0.09 | -0.15% (noise) |
| Qwen3.5-35B-A3B (Q4_K_M) | 57.75 ± 0.07 | 57.75 ± 0.07 | 0.0% |

## Test plan
- [x] Roofline traces: MMQ compact path active in prefill, absent in decode.
- [x] E2E `llama-bench` prefill A/B across 4 MoE models (above).
- [x] `test-backend-ops -o MUL_MAT_ID` with default-on: **790/790 pass** (gfx1151).
