### PR TITLE
ci(gfx11): temporarily disable gfx1151 hardware test (runner offline)

### DIFF
--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -357,7 +357,11 @@ jobs:
 
   test-gfx:
     needs: build-ubuntu
-    if: needs.build-ubuntu.result == 'success'
+    # TEMPORARILY DISABLED: the linux-gfx1151-gpu-rocm self-hosted runner is
+    # offline, so this job sits queued indefinitely and blocks create-release.
+    # Re-enable by restoring `needs.build-ubuntu.result == 'success'` once the
+    # runner is back online.
+    if: false && needs.build-ubuntu.result == 'success'
     # Single hardware test of the multiarch artifact on gfx1151. This is the
     # end-to-end safety net for the Tensile-only multiarch package: a real
     # llama-cli inference exercising the rocBLAS/hipBLASLt GEMM path on-device.
@@ -499,17 +503,19 @@ jobs:
         fi
 
   create-release:
-    needs: [build-ubuntu, test-gfx]
+    needs: [build-ubuntu]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     # Publish only on the nightly dispatch (external cron passes
     # -f create_release=true). Push/PR and manual runs never release.
-    # Require the build to succeed and the gfx1151 hardware test to pass.
+    # Require the build to succeed. NOTE: the gfx1151 hardware-test gate
+    # (needs.test-gfx.result == 'success') is TEMPORARILY REMOVED while the
+    # self-hosted runner is offline and test-gfx is disabled above. Restore both
+    # the `test-gfx` entry in needs and the result check when the runner returns.
     if: |
       always() &&
       needs.build-ubuntu.result == 'success' &&
-      needs.test-gfx.result == 'success' &&
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.create_release == 'true'
     steps:


### PR DESCRIPTION
## Summary

The `linux-gfx1151-gpu-rocm` self-hosted runner is currently offline, so the `test-gfx` job sits `queued` indefinitely and blocks `create-release` — the nightly can build but never publishes. This temporarily disables the hardware test so releases flow again.

## Changes

- **`test-gfx`**: gated off via `if: false && ...` (job body kept intact so re-enabling is a one-line revert).
- **`create-release`**: dropped `test-gfx` from `needs` and removed the `needs.test-gfx.result == 'success'` gate. Still requires `build-ubuntu` success + `workflow_dispatch` + `create_release=true`, so push/PR still never release.

## Revert plan

When the gfx1151 runner is back online, restore:
1. `test-gfx` `if: needs.build-ubuntu.result == 'success'`
2. `create-release` `needs: [build-ubuntu, test-gfx]` + the `needs.test-gfx.result == 'success'` line

Both spots carry TODO comments pointing at each other.

## Context

Three nightly dispatches (build-ubuntu green) are stuck queued on the missing runner right now; this unblocks them / future nightlies from publishing. Correctness of the multiarch package is still validated at build time; only the on-device inference smoke test is paused.

## Test plan

- [x] Dispatch with `create_release=true` and confirm: build succeeds, `test-gfx` is skipped, `create-release` runs and publishes.
- [x] Confirm push/PR still builds only and never releases.