### PR TITLE
ci(gfx11): add gfx1152 to the multiarch ROCm build

### DIFF
--- a/.github/workflows/build-gfx11-rocm.yml
+++ b/.github/workflows/build-gfx11-rocm.yml
@@ -42,9 +42,9 @@ jobs:
     # Single multiarch build: one fat binary covering all current CI arches,
     # sourced from TheRock's multiarch tarball (arch-neutral host + per-arch
     # Tensile DBs). gfx1100-1103 (RDNA3 desktop + Hawk Point/Phoenix 760M/780M),
-    # gfx1150/1151/1153 (RDNA3.5 Strix APUs).
+    # gfx1150/1151/1152/1153 (RDNA3.5 Strix APUs).
     env:
-      GPU_TARGETS: gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1153
+      GPU_TARGETS: gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153
     outputs:
       rocm_version: ${{ steps.set-outputs.outputs.rocm_version }}
       llamacpp_commit_hash: ${{ steps.set-outputs.outputs.llamacpp_commit_hash }}
@@ -158,7 +158,7 @@ jobs:
 
         # The multiarch tarball (~11.5 GB) ships device code for ALL 26 GPU
         # arches: every arch's .kpack plus per-arch rocBLAS/hipBLASLt Tensile DBs.
-        # This consumer build only needs the 7 RDNA3/3.5 arches in GPU_TARGETS and
+        # This consumer build only needs the 8 RDNA3/3.5 arches in GPU_TARGETS and
         # uses the GEMM (Tensile) path, which works without .kpack files. So we
         # stream-extract and prune at the tar level: drop ALL .kpack, and drop the
         # Tensile DBs of every arch not in our target set. This keeps the runner
@@ -167,7 +167,7 @@ jobs:
         # names, hence the leading "./".
         drop_arches="gfx900 gfx906 gfx908 gfx90a gfx942 gfx950 \
           gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1033 gfx1034 gfx1035 gfx1036 \
-          gfx1152 gfx1200 gfx1201"
+          gfx1200 gfx1201"
         excludes=(--exclude='./.kpack' --exclude='./.kpack/*')
         for a in $drop_arches; do
           excludes+=("--exclude=./lib/*/library/${a}")
@@ -681,10 +681,10 @@ jobs:
           --title "$TAG" \
           --notes "**Build**: $TAG
         **OS**: ubuntu
-        **GPU Target(s)**: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1153 (single multiarch binary)
+        **GPU Target(s)**: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153 (single multiarch binary)
         **ROCm Version**: $ROCM_VERSION (multiarch)
         **Llama.cpp Commit**: $LLAMACPP_COMMIT_HASH
         **Build Date**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
-        Prebuilt llama.cpp ROCm binaries — one multiarch package covering the RDNA3 gfx110X family incl. Hawk Point/Phoenix (Radeon 760M/780M) and the RDNA3.5 gfx115x APUs (gfx1150/gfx1151/gfx1153). Built from TheRock's multiarch ROCm runtime, pruned to the CI target arches (per-arch Tensile databases bundled)." \
+        Prebuilt llama.cpp ROCm binaries — one multiarch package covering the RDNA3 gfx110X family incl. Hawk Point/Phoenix (Radeon 760M/780M) and the RDNA3.5 gfx115x APUs (gfx1150/gfx1151/gfx1152/gfx1153). Built from TheRock's multiarch ROCm runtime, pruned to the CI target arches (per-arch Tensile databases bundled)." \
           *.tar.gz


### PR DESCRIPTION
## Summary
- Enable gfx1152 (RDNA3.5 Strix APU) in the gfx11 multiarch ROCm build.
- Device code already handles gfx1152 (the `RDNA3_5` macro in `vendors/hip.h` and the `GGML_CUDA_CC_IS_RDNA3_5` range in `common.cuh` both cover `0x1152`). The gap was build-only:
  - `gfx1152` was missing from `GPU_TARGETS`.
  - `gfx1152` was in `drop_arches`, so its rocBLAS/hipBLASLt Tensile DBs were being pruned out of the package.
- Fix: add gfx1152 to `GPU_TARGETS`, remove it from the prune list, update arch counts and release notes.
- Verified the gfx1152 Tensile DBs (rocblas + hipblaslt) are present in the 7.15 nightly, same as gfx1151.

## Test plan
- [x] CI multiarch build is green with gfx1152 in GPU_TARGETS.
- [x] Release package contains gfx1152 rocblas/hipblaslt Tensile DBs (not pruned).