### PR TITLE
[AIESW-40114] ggml-hip: drop unconditional -ffast-math on gfx11

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -175,5 +175,3 @@ if (GGML_HIP_ROOFLINE)
     target_compile_definitions(ggml-hip PRIVATE GGML_HIP_ROOFLINE)
     target_link_libraries(ggml-hip PRIVATE ${CMAKE_DL_LIBS})
 endif()
-
-target_compile_options(ggml-hip PRIVATE "$<$<COMPILE_LANGUAGE:HIP>:-ffast-math;-fno-finite-math-only>")


### PR DESCRIPTION
Drop the unconditional `-ffast-math;-fno-finite-math-only` compile option on the HIP backend.

The Aug-7 origin/master sync merge re-added `target_compile_options(ggml-hip PRIVATE -ffast-math ...)` that upstream #25495 had removed. `-ffast-math` implies `-funsafe-math-optimizations` (`-fassociative-math`), which reassociates FP reductions and flips greedy argmax on gfx1151, making MTP speculative-decode output diverge from the non-spec baseline (AIESW-40114). This defeated the existing `GGML_HIP_UNSAFE_MATH` gate (default OFF). Removing the line makes HIP builds IEEE-conformant by default; the fast-math speedup is still available opt-in via `-DGGML_HIP_UNSAFE_MATH=ON`.

Validated on gfx1151 (halo05): with unsafe math off, baseline `--spec-type none` and `--spec-type draft-mtp` produce byte-identical greedy output.

Jira: https://jira.xilinx.com/browse/AIESW-40114