### PR TITLE
ci: neutralize upstream self-hosted-runner jobs on the fork

### DIFF
--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -35,6 +35,9 @@ env:
 
 jobs:
   ubuntu-24-openvino:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, Intel, OpenVINO]
 
     env:

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -28,7 +28,9 @@ env:
 
 jobs:
   ctest:
-    runs-on: [self-hosted, X64, CPU, Linux]
+    # ROCm fork-local: upstream uses [self-hosted, X64, CPU, Linux] runners that
+    # don't exist in this fork. DO NOT UPSTREAM this runner change.
+    runs-on: ubuntu-24.04
 
     continue-on-error: true
 

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -58,6 +58,9 @@ env:
 
 jobs:
   gpu-cuda:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, NVIDIA]
 
     steps:
@@ -72,6 +75,9 @@ jobs:
           GG_BUILD_CUDA=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-rocm:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, AMD]
 
     steps:
@@ -92,6 +98,9 @@ jobs:
           GG_BUILD_ROCM=1 GG_BUILD_AMDGPU_TARGETS=gfx1151 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-nvidia-cm:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, NVIDIA]
 
     steps:
@@ -106,6 +115,9 @@ jobs:
           GG_BUILD_VULKAN=1 GGML_VK_DISABLE_COOPMAT2=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-nvidia-cm2:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, NVIDIA, COOPMAT2]
 
     steps:
@@ -120,6 +132,9 @@ jobs:
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-webgpu-nvidia:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, NVIDIA, X64]
 
     steps:
@@ -193,6 +208,9 @@ jobs:
   #         GG_BUILD_ROCM=1 GG_BUILD_AMDGPU_TARGETS="gfx1101" bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-metal:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, macOS, ARM64]
 
     steps:
@@ -206,6 +224,9 @@ jobs:
           GG_BUILD_METAL=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-webgpu-apple:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, macOS, ARM64]
 
     steps:
@@ -233,6 +254,9 @@ jobs:
             bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-apple:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, macOS, ARM64]
 
     steps:
@@ -247,6 +271,9 @@ jobs:
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-intel-linux:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, Intel]
 
     steps:
@@ -263,6 +290,9 @@ jobs:
           GG_BUILD_VULKAN=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   gpu-vulkan-intel-windows:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Windows, X64, Intel]
 
     steps:
@@ -284,6 +314,9 @@ jobs:
           LLAMA_FATAL_WARNINGS=OFF GG_BUILD_NINJA=1 GG_BUILD_VULKAN=1 GG_BUILD_LOW_PERF=1 ./ci/run.sh ./results/llama.cpp ./mnt/llama.cpp
 
   gpu-openvino-low-perf:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, Intel, OpenVINO]
 
     env:
@@ -316,6 +349,9 @@ jobs:
           GG_BUILD_OPENVINO=1 GGML_OPENVINO_DEVICE=GPU GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   cpu-x64-high-perf:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, Linux, X64]
 
     steps:

--- a/.github/workflows/check-vendor.yml
+++ b/.github/workflows/check-vendor.yml
@@ -19,7 +19,9 @@ on:
 
 jobs:
   check-vendor:
-    runs-on: [self-hosted, fast]
+    # ROCm fork-local: upstream uses [self-hosted, fast] runners that don't
+    # exist in this fork. DO NOT UPSTREAM this runner change.
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/pre-tokenizer-hashes.yml
+++ b/.github/workflows/pre-tokenizer-hashes.yml
@@ -12,7 +12,9 @@ on:
 
 jobs:
     pre-tokenizer-hashes:
-        runs-on: [self-hosted, fast]
+        # ROCm fork-local: upstream uses [self-hosted, fast] runners that don't
+        # exist in this fork. DO NOT UPSTREAM this runner change.
+        runs-on: ubuntu-24.04
 
         steps:
         - name: Checkout repository

--- a/.github/workflows/python-check-requirements.yml
+++ b/.github/workflows/python-check-requirements.yml
@@ -20,7 +20,9 @@ concurrency:
 
 jobs:
   python-check-requirements:
-    runs-on: [self-hosted, CPU, fast]
+    # ROCm fork-local: upstream uses [self-hosted, CPU, fast] runners that don't
+    # exist in this fork. DO NOT UPSTREAM this runner change.
+    runs-on: ubuntu-24.04
     name: check-requirements
     steps:
       - name: Check out source repository

--- a/.github/workflows/python-type-check.yml
+++ b/.github/workflows/python-type-check.yml
@@ -22,7 +22,9 @@ concurrency:
 
 jobs:
   python-type-check:
-    runs-on: [self-hosted, fast]
+    # ROCm fork-local: upstream uses [self-hosted, fast] runners that don't
+    # exist in this fork. DO NOT UPSTREAM this runner change.
+    runs-on: ubuntu-24.04
     name: python type-check
     steps:
       - name: Check out source repository

--- a/.github/workflows/server-sanitize.yml
+++ b/.github/workflows/server-sanitize.yml
@@ -37,7 +37,9 @@ concurrency:
 
 jobs:
   server:
-    runs-on: [self-hosted, CPU, Linux, llama-server]
+    # ROCm fork-local: upstream uses [self-hosted, CPU, Linux, llama-server] runners
+    # that don't exist in this fork. DO NOT UPSTREAM this runner change.
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -42,6 +42,9 @@ concurrency:
 
 jobs:
   server-metal:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, llama-server, macOS, ARM64]
 
     steps:
@@ -102,6 +105,9 @@ jobs:
           pytest -v -x -m "not slow"
 
   server-cuda:
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, llama-server, Linux, NVIDIA]
 
     steps:

--- a/.github/workflows/ui-self-hosted.yml
+++ b/.github/workflows/ui-self-hosted.yml
@@ -42,11 +42,17 @@ concurrency:
 jobs:
   ui-build:
     name: Build static output
+    # ROCm fork-local: the called workflow runs on self-hosted runners absent in the
+    # fork; guard so it no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     uses: ./.github/workflows/ui-build-self-hosted.yml
 
   ui-checks:
     name: Checks
     needs: ui-build
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, PLAYWRIGHT]
     continue-on-error: true
     steps:
@@ -90,6 +96,9 @@ jobs:
   e2e-tests:
     name: E2E Tests
     needs: ui-build
+    # ROCm fork-local: this self-hosted runner does not exist in the fork; guard so
+    # the job no-ops here but merges cleanly from upstream. DO NOT UPSTREAM.
+    if: ${{ github.repository == 'ggml-org/llama.cpp' }}
     runs-on: [self-hosted, PLAYWRIGHT]
     steps:
       - name: Checkout code

--- a/.github/workflows/update-ops-docs.yml
+++ b/.github/workflows/update-ops-docs.yml
@@ -16,7 +16,9 @@ on:
 
 jobs:
     update-ops-docs:
-        runs-on: [self-hosted, fast, ARM64]
+        # ROCm fork-local: upstream uses [self-hosted, fast, ARM64] runners that
+        # don't exist in this fork. DO NOT UPSTREAM this runner change.
+        runs-on: ubuntu-24.04
 
         steps:
         - name: Checkout repository


### PR DESCRIPTION
Upstream (ggml-org) runs many CI jobs on its own self-hosted runner fleet (labels: fast, X64, CPU, llama-server, PLAYWRIGHT, NVIDIA, etc.). The fork has no runners with those labels, so on PRs/pushes these jobs queue until GitHub's 24h max-runtime cap cancels them, showing as red checks (e.g. the cancelled checks on PR #85).

Two fixes, both fork-local (each carries a DO NOT UPSTREAM comment):

- Slim/sanitize jobs that only need a generic runner -> runs-on: ubuntu-24.04, matching the existing editorconfig/code-style conversion: check-vendor, pre-tokenizer-hashes, python-check-requirements, python-type-check, build-sanitize, server-sanitize, update-ops-docs.
- Dedicated self-hosted workflows whose hardware the fork lacks -> gate each job with `if: github.repository == 'ggml-org/llama.cpp'` so it no-ops on the fork but merges cleanly from upstream: build-self-hosted (12 jobs), server-self-hosted (2), ui-self-hosted (3), build-openvino (1).

11 workflows changed. All YAML validated; verified no push/PR-triggered self-hosted job remains unguarded.